### PR TITLE
Add country CRUD endpoints

### DIFF
--- a/Sakila.API/Controllers/CountriesController.cs
+++ b/Sakila.API/Controllers/CountriesController.cs
@@ -1,0 +1,49 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Queries;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.API.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class CountriesController(IMediator mediator) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<CountryGetAllResponse>> GetAll()
+    {
+        var countries = await mediator.Send(new CountryGetAllRequest());
+        return Ok(countries);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<CountryGetByIdResponse>> GetById(int id)
+    {
+        var country = await mediator.Send(new CountryGetByIdRequest { Id = id });
+        return country == null ? NotFound() : Ok(country);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> PutCountry(int id, CountryUpdateRequest command)
+    {
+        if (id != command.Id) return BadRequest();
+
+        await mediator.Send(command);
+        return NoContent();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> PostCountry(CountryCreateRequest command)
+    {
+        var id = await mediator.Send(command);
+        return CreatedAtAction(nameof(GetById), new { id }, command);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteCountry(int id)
+    {
+        var result = await mediator.Send(new CountryDeleteRequest { Id = id });
+        return result ? NoContent() : NotFound();
+    }
+}

--- a/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using MediatR;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Handlers;
+
+public class CreateHandler(
+    SakilaContext context,
+    IMapper mapper) : IRequestHandler<CountryCreateRequest, int>
+{
+    public async Task<int> Handle(CountryCreateRequest request, CancellationToken cancellationToken)
+    {
+        var country = mapper.Map<Country>(request);
+
+        context.Countries.Add(country);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return country.CountryId;
+    }
+}

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -1,0 +1,17 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Handlers;
+
+public class DeleteHandler(SakilaContext context) : IRequestHandler<CountryDeleteRequest, bool>
+{
+    public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
+    {
+        var country = await context.Countries.FirstAsync(c => c.CountryId == request.Id, cancellationToken);
+        context.Countries.Remove(country);
+        await context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Handlers;
+
+public class UpdateHandler(SakilaContext context, IMapper mapper)
+    : IRequestHandler<CountryUpdateRequest, Unit>
+{
+    public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
+    {
+        var country = await context.Countries
+            .FirstAsync(c => c.CountryId == request.Id, cancellationToken);
+
+        mapper.Map(request, country);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/Sakila.Application/Countries/Commands/Mapping/CreateProfile.cs
+++ b/Sakila.Application/Countries/Commands/Mapping/CreateProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Countries.Commands.Mapping;
+
+public class CreateProfile : Profile
+{
+    public CreateProfile()
+    {
+        CreateMap<CountryCreateRequest, Country>()
+            .ForMember(dest => dest.Country1, opt => opt.MapFrom(src => src.Name));
+    }
+}

--- a/Sakila.Application/Countries/Commands/Mapping/UpdateProfile.cs
+++ b/Sakila.Application/Countries/Commands/Mapping/UpdateProfile.cs
@@ -1,0 +1,15 @@
+using AutoMapper;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Countries.Commands.Mapping;
+
+public class UpdateProfile : Profile
+{
+    public UpdateProfile()
+    {
+        CreateMap<CountryUpdateRequest, Country>()
+            .ForMember(dest => dest.CountryId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Country1, opt => opt.MapFrom(src => src.Name));
+    }
+}

--- a/Sakila.Application/Countries/Commands/Validators/CreateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CreateValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Validators;
+
+public class CreateValidator : AbstractValidator<CountryCreateRequest>
+{
+    public CreateValidator(SakilaContext context)
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Country name is required.")
+            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.")
+            .Must(name => !context.Countries.Any(c => c.Country1 == name))
+            .WithMessage("A country with this name already exists.");
+    }
+}

--- a/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Validators;
+
+public class DeleteValidator : AbstractValidator<CountryDeleteRequest>
+{
+    public DeleteValidator(SakilaContext context)
+    {
+        RuleFor(x => x.Id)
+            .Must(id => context.Countries.Any(c => c.CountryId == id))
+            .WithMessage("Country not found.");
+    }
+}

--- a/Sakila.Application/Countries/Commands/Validators/UpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/UpdateValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Commands.Validators;
+
+public class UpdateValidator : AbstractValidator<CountryUpdateRequest>
+{
+    public UpdateValidator(SakilaContext context)
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Country name is required.")
+            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.")
+            .Must((cmd, name) => !context.Countries.Any(c => c.Country1 == name && c.CountryId != cmd.Id))
+            .WithMessage("Another country with this name already exists.");
+    }
+}

--- a/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sakila.Contracts.Countries.Queries;
+using Sakila.Contracts.Countries.Responses;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Queries.Handlers;
+
+public class GetAllHandler(SakilaContext context, IMapper mapper)
+    : IRequestHandler<CountryGetAllRequest, CountryGetAllResponse>
+{
+    public async Task<CountryGetAllResponse> Handle(CountryGetAllRequest request,
+        CancellationToken cancellationToken)
+    {
+        return new CountryGetAllResponse
+        {
+            Countries = await mapper.ProjectTo<CountryGetByIdResponse>(context.Countries)
+                .ToListAsync(cancellationToken)
+        };
+    }
+}

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sakila.Contracts.Countries.Queries;
+using Sakila.Contracts.Countries.Responses;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Queries.Handlers;
+
+public class GetByIdHandler(SakilaContext context, IMapper mapper)
+    : IRequestHandler<CountryGetByIdRequest, CountryGetByIdResponse?>
+{
+    public async Task<CountryGetByIdResponse?> Handle(CountryGetByIdRequest request,
+        CancellationToken cancellationToken)
+    {
+        return await context.Countries
+            .Where(c => c.CountryId == request.Id)
+            .ProjectTo<CountryGetByIdResponse>(mapper.ConfigurationProvider)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/Sakila.Application/Countries/Queries/Mapping/GetByIdProfile.cs
+++ b/Sakila.Application/Countries/Queries/Mapping/GetByIdProfile.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using Sakila.Contracts.Countries.Responses;
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Countries.Queries.Mapping;
+
+public class GetByIdProfile : Profile
+{
+    public GetByIdProfile()
+    {
+        CreateMap<Country, CountryGetByIdResponse>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.CountryId))
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Country1))
+            .ReverseMap();
+    }
+}

--- a/Sakila.Application/Countries/Queries/Validators/GetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/GetByIdValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Queries;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Countries.Queries.Validators;
+
+public class GetByIdValidator : AbstractValidator<CountryGetByIdRequest>
+{
+    public GetByIdValidator(SakilaContext context)
+    {
+        RuleFor(x => x.Id)
+            .Must(id => context.Countries.Any(c => c.CountryId == id))
+            .WithMessage("Country not found.");
+    }
+}

--- a/Sakila.Contracts/Countries/Commands/CountryCreateRequest.cs
+++ b/Sakila.Contracts/Countries/Commands/CountryCreateRequest.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Sakila.Contracts.Countries.Commands;
+
+public class CountryCreateRequest : IRequest<int>
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/Sakila.Contracts/Countries/Commands/CountryDeleteRequest.cs
+++ b/Sakila.Contracts/Countries/Commands/CountryDeleteRequest.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Sakila.Contracts.Countries.Commands;
+
+public class CountryDeleteRequest : IRequest<bool>
+{
+    public int Id { get; set; }
+}

--- a/Sakila.Contracts/Countries/Commands/CountryUpdateRequest.cs
+++ b/Sakila.Contracts/Countries/Commands/CountryUpdateRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Sakila.Contracts.Countries.Commands;
+
+public class CountryUpdateRequest : IRequest<Unit>
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/Sakila.Contracts/Countries/Queries/CountryGetAllRequest.cs
+++ b/Sakila.Contracts/Countries/Queries/CountryGetAllRequest.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.Contracts.Countries.Queries;
+
+public class CountryGetAllRequest : IRequest<CountryGetAllResponse>;

--- a/Sakila.Contracts/Countries/Queries/CountryGetByIdRequest.cs
+++ b/Sakila.Contracts/Countries/Queries/CountryGetByIdRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.Contracts.Countries.Queries;
+
+public class CountryGetByIdRequest : IRequest<CountryGetByIdResponse?>
+{
+    public int Id { get; set; }
+}

--- a/Sakila.Contracts/Countries/Responses/CountryGetAllResponse.cs
+++ b/Sakila.Contracts/Countries/Responses/CountryGetAllResponse.cs
@@ -1,0 +1,6 @@
+namespace Sakila.Contracts.Countries.Responses;
+
+public class CountryGetAllResponse
+{
+    public List<CountryGetByIdResponse> Countries { get; set; } = new();
+}

--- a/Sakila.Contracts/Countries/Responses/CountryGetByIdResponse.cs
+++ b/Sakila.Contracts/Countries/Responses/CountryGetByIdResponse.cs
@@ -1,0 +1,7 @@
+namespace Sakila.Contracts.Countries.Responses;
+
+public class CountryGetByIdResponse
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+}

--- a/Sakila.Contracts/Sakila.Contracts.csproj
+++ b/Sakila.Contracts/Sakila.Contracts.csproj
@@ -67,6 +67,13 @@
     <Compile Include="Languages\Queries\LanguageGetByIdRequest.cs" />
     <Compile Include="Languages\Responses\LanguageGetAllResponse.cs" />
     <Compile Include="Languages\Responses\LanguageGetByIdResponse.cs" />
+    <Compile Include="Countries\Commands\CountryCreateRequest.cs" />
+    <Compile Include="Countries\Commands\CountryDeleteRequest.cs" />
+    <Compile Include="Countries\Commands\CountryUpdateRequest.cs" />
+    <Compile Include="Countries\Queries\CountryGetAllRequest.cs" />
+    <Compile Include="Countries\Queries\CountryGetByIdRequest.cs" />
+    <Compile Include="Countries\Responses\CountryGetAllResponse.cs" />
+    <Compile Include="Countries\Responses\CountryGetByIdResponse.cs" />
     <Compile Include="Services\ILanguageService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add contract models for Country commands, queries and responses
- implement Country handlers, mappers and validators
- expose Country API controller
- include country models in Contracts project

## Testing
- `dotnet build CRUD-DSC.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e405998832ebe33672986d0e74c