### PR TITLE
Add country service and pages

### DIFF
--- a/Sakila.Contracts/Services/ICountryService.cs
+++ b/Sakila.Contracts/Services/ICountryService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.Contracts.Services;
+
+public interface ICountryService
+{
+    Task<CountryGetAllResponse> GetAllAsync();
+    Task<CountryGetByIdResponse> GetByIdAsync(int id);
+    Task CreateAsync(CountryCreateRequest request);
+    Task UpdateAsync(CountryUpdateRequest request);
+    Task DeleteAsync(int id);
+}

--- a/Sakila.Infrastructure/Data/SakilaContext.cs
+++ b/Sakila.Infrastructure/Data/SakilaContext.cs
@@ -58,7 +58,10 @@ public partial class SakilaContext : DbContext
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseSqlServer("Name=DefaultConnection");
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder.UseSqlServer("Name=DefaultConnection");
+        }
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtensions
     {
         builder.Services.AddScoped<IApiClient, ApiClient>();
         builder.Services.AddScoped<ILanguageService, LanguageService>();
+        builder.Services.AddScoped<ICountryService, CountryService>();
         builder.Services.AddScoped(sp => new HttpClient
             { BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"]!) });
         return builder;

--- a/Sakila.Web/Layout/NavMenu.razor
+++ b/Sakila.Web/Layout/NavMenu.razor
@@ -19,5 +19,10 @@
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Languages
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="countries">
+                <span class="bi bi-globe2-nav-menu" aria-hidden="true"></span> Countries
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -1,0 +1,19 @@
+@if (Visible)
+{
+    <div class="modal show d-block" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirm Deletion</h5>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to delete <strong>@Country.Name</strong>?</p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="OnCancel">No</button>
+                    <button class="btn btn-danger" @onclick="OnConfirm">Yes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Components;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.Web.Pages.Countries.Components;
+
+public partial class ConfirmDelete
+{
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
+    [Parameter] public Dictionary<string, string[]> Errors { get; set; } = new();
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnConfirm { get; set; }
+}

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
@@ -1,0 +1,20 @@
+@using Sakila.Web.Pages.Components
+@if (Visible)
+{
+    <div class="modal show d-block" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">@Title Country</h5>
+                </div>
+                <div class="modal-body">
+                    <FormTextInput @bind-Value="Country.Name" Label="Country Name" Field="Name" Errors="Errors"/>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                    <button class="btn btn-primary" @onclick="OnSubmit">@Title</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components;
+using Sakila.Contracts.Countries.Responses;
+
+namespace Sakila.Web.Pages.Countries.Components;
+
+public partial class CountryFormDialog
+{
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
+    [Parameter] public Dictionary<string, string[]> Errors { get; set; } = new();
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnSubmit { get; set; }
+    private string Title => Country.Id != 0 ? "Edit" : "Add";
+}

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -1,0 +1,48 @@
+@page "/countries"
+@using Sakila.Web.Pages.Countries.Components
+
+<h3>Countries</h3>
+
+<button class="btn btn-primary mb-3" @onclick="() => ShowDialog()">Add Country</button>
+
+@if (_params == null)
+{
+    <p>
+        <em>Loading...</em>
+    </p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Name</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var country in _params.Countries)
+        {
+            <tr>
+                <td>@country.Name</td>
+                <td>
+                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowDialog(country)">Edit</button>
+                    <button class="btn btn-sm btn-danger" @onclick="() => ShowDeleteDialog(country)">Delete</button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+<CountryFormDialog Visible="_isDialogOpen"
+                  Country="_selectedCountry"
+                  Errors="Errors"
+                  OnCancel="CloseDialog"
+                  OnSubmit="SubmitCountry"/>
+
+<ConfirmDelete Visible="_isDeleteDialogOpen"
+               Country="_selectedCountry"
+               Errors="Errors"
+               OnCancel="CloseDeleteDialog"
+               OnConfirm="ConfirmDelete"/>

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Components;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Responses;
+using Sakila.Contracts.Services;
+using Sakila.Web.Common;
+
+namespace Sakila.Web.Pages.Countries;
+
+public partial class List
+{
+    private bool _isDeleteDialogOpen;
+    private bool _isDialogOpen;
+    private CountryGetAllResponse? _params;
+    private CountryGetByIdResponse _selectedCountry = new();
+    [Inject] public ICountryService CountryService { get; set; } = null!;
+    private Dictionary<string, string[]> Errors { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _params = await CountryService.GetAllAsync();
+    }
+
+    private void ShowDialog(CountryGetByIdResponse? country = null)
+    {
+        if (country is null)
+        {
+            _selectedCountry = new CountryGetByIdResponse();
+        }
+        else
+        {
+            _selectedCountry = new CountryGetByIdResponse
+            {
+                Id = country.Id,
+                Name = country.Name
+            };
+        }
+
+        Errors = new();
+        _isDialogOpen = true;
+    }
+
+    private void CloseDialog()
+    {
+        _isDialogOpen = false;
+        _selectedCountry = new CountryGetByIdResponse();
+        Errors = new();
+    }
+
+    private async Task SubmitCountry()
+    {
+        try
+        {
+            if (_selectedCountry.Id == 0)
+            {
+                var request = new CountryCreateRequest { Name = _selectedCountry.Name };
+                await CountryService.CreateAsync(request);
+            }
+            else
+            {
+                var request = new CountryUpdateRequest { Id = _selectedCountry.Id, Name = _selectedCountry.Name };
+                await CountryService.UpdateAsync(request);
+            }
+            await RefreshCountries();
+            CloseDialog();
+        }
+        catch (ApiValidationException exception)
+        {
+            Errors = exception.Errors;
+        }
+    }
+
+    private async Task RefreshCountries()
+    {
+        _params = await CountryService.GetAllAsync();
+    }
+
+    private void ShowDeleteDialog(CountryGetByIdResponse country)
+    {
+        _selectedCountry = country;
+        Errors = new();
+        _isDeleteDialogOpen = true;
+    }
+
+    private void CloseDeleteDialog()
+    {
+        _isDeleteDialogOpen = false;
+        Errors = new();
+    }
+
+    private async Task ConfirmDelete()
+    {
+        try
+        {
+            await CountryService.DeleteAsync(_selectedCountry.Id);
+            await RefreshCountries();
+            CloseDeleteDialog();
+        }
+        catch (ApiValidationException exception)
+        {
+            Errors = exception.Errors;
+        }
+    }
+}

--- a/Sakila.Web/Services/CountryService.cs
+++ b/Sakila.Web/Services/CountryService.cs
@@ -1,0 +1,36 @@
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Responses;
+using Sakila.Contracts.Services;
+using Sakila.Web.Common;
+
+namespace Sakila.Web.Services;
+
+public class CountryService(IApiClient apiClient) : ICountryService
+{
+    private readonly string _resource = "countries";
+
+    public async Task<CountryGetAllResponse> GetAllAsync()
+    {
+        return await apiClient.GetAsync<CountryGetAllResponse>(_resource);
+    }
+
+    public async Task<CountryGetByIdResponse> GetByIdAsync(int id)
+    {
+        return await apiClient.GetAsync<CountryGetByIdResponse>($"{_resource}/{id}");
+    }
+
+    public async Task CreateAsync(CountryCreateRequest request)
+    {
+        await apiClient.PostAsync(_resource, request);
+    }
+
+    public async Task UpdateAsync(CountryUpdateRequest request)
+    {
+        await apiClient.PutAsync($"{_resource}/{request.Id}", request);
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        await apiClient.DeleteAsync($"{_resource}/{id}");
+    }
+}


### PR DESCRIPTION
## Summary
- add `ICountryService` abstraction
- implement `CountryService` with CRUD http helpers
- register `CountryService` in `ServiceCollectionExtensions`
- add Countries Razor components and List page
- update nav menu
- avoid overriding connection string when options already configured

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f53e59c80832eac4a3ebf95773225