### PR TITLE
Inline validation in handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ La solución está organizada siguiendo los principios de **Clean Architecture**
 ### 🔹 `Sakila.API` – ASP.NET Core Web API
 - Exposición de endpoints RESTful (`/api/languages`, etc.)
 - Controladores minimalistas con `IMediator` (MediatR)
-- Validaciones automáticas con `FluentValidation` vía `ValidationBehavior`
+- Validaciones ejecutadas en los handlers con `FluentValidation`
 - Proyecciones eficientes de datos con `AutoMapper.ProjectTo<>`
 
 ### 🔹 `Sakila.Application` – Lógica de aplicación y casos de uso

--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -4,10 +4,16 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using Sakila.API.Middleware;
 using Sakila.API.Options;
-using Sakila.Application.Common.Behaviors;
 using Sakila.Application.Languages.Commands.Handlers;
 using Sakila.Application.Languages.Commands.Validators;
 using Sakila.Application.Languages.Queries.Mapping;
+using Sakila.Application.Languages.Queries.Validators;
+using Sakila.Application.Countries.Commands.Validators;
+using Sakila.Application.Countries.Queries.Validators;
+using Sakila.Contracts.Languages.Commands;
+using Sakila.Contracts.Languages.Queries;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Queries;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.API.Extensions;
@@ -38,9 +44,16 @@ public static class ServiceCollectionExtensions
         services
             .AddMediatR(serviceConfiguration =>
                 serviceConfiguration.RegisterServicesFromAssembly(typeof(CreateHandler).Assembly))
-            .AddAutoMapper(typeof(GetByIdProfile).Assembly)
-            .AddValidatorsFromAssembly(typeof(CreateValidator).Assembly)
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+            .AddAutoMapper(typeof(GetByIdProfile).Assembly);
+
+        services.AddTransient<IValidator<LanguageCreateRequest>, CreateValidator>();
+        services.AddTransient<IValidator<LanguageUpdateRequest>, UpdateValidator>();
+        services.AddTransient<IValidator<LanguageDeleteRequest>, DeleteValidator>();
+        services.AddTransient<IValidator<LanguageGetByIdRequest>, GetByIdValidator>();
+        services.AddTransient<IValidator<CountryCreateRequest>, Sakila.Application.Countries.Commands.Validators.CreateValidator>();
+        services.AddTransient<IValidator<CountryUpdateRequest>, Sakila.Application.Countries.Commands.Validators.UpdateValidator>();
+        services.AddTransient<IValidator<CountryDeleteRequest>, Sakila.Application.Countries.Commands.Validators.DeleteValidator>();
+        services.AddTransient<IValidator<CountryGetByIdRequest>, Sakila.Application.Countries.Queries.Validators.GetByIdValidator>();
 
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(c =>

--- a/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
@@ -8,10 +9,13 @@ namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class CreateHandler(
     SakilaContext context,
-    IMapper mapper) : IRequestHandler<CountryCreateRequest, int>
+    IMapper mapper,
+    IValidator<CountryCreateRequest> validator) : IRequestHandler<CountryCreateRequest, int>
 {
     public async Task<int> Handle(CountryCreateRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var country = mapper.Map<Country>(request);
 
         context.Countries.Add(country);

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
@@ -5,10 +6,14 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
-public class DeleteHandler(SakilaContext context) : IRequestHandler<CountryDeleteRequest, bool>
+public class DeleteHandler(
+    SakilaContext context,
+    IValidator<CountryDeleteRequest> validator) : IRequestHandler<CountryDeleteRequest, bool>
 {
     public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var country = await context.Countries.FirstAsync(c => c.CountryId == request.Id, cancellationToken);
         context.Countries.Remove(country);
         await context.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
@@ -6,11 +7,16 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
-public class UpdateHandler(SakilaContext context, IMapper mapper)
+public class UpdateHandler(
+    SakilaContext context,
+    IMapper mapper,
+    IValidator<CountryUpdateRequest> validator)
     : IRequestHandler<CountryUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var country = await context.Countries
             .FirstAsync(c => c.CountryId == request.Id, cancellationToken);
 

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Queries;
@@ -8,12 +9,17 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Handlers;
 
-public class GetByIdHandler(SakilaContext context, IMapper mapper)
+public class GetByIdHandler(
+    SakilaContext context,
+    IMapper mapper,
+    IValidator<CountryGetByIdRequest> validator)
     : IRequestHandler<CountryGetByIdRequest, CountryGetByIdResponse?>
 {
     public async Task<CountryGetByIdResponse?> Handle(CountryGetByIdRequest request,
         CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         return await context.Countries
             .Where(c => c.CountryId == request.Id)
             .ProjectTo<CountryGetByIdResponse>(mapper.ConfigurationProvider)

--- a/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
@@ -8,11 +9,14 @@ namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class CreateHandler(
     SakilaContext context,
-    IMapper mapper)
+    IMapper mapper,
+    IValidator<LanguageCreateRequest> validator)
     : IRequestHandler<LanguageCreateRequest, int>
 {
     public async Task<int> Handle(LanguageCreateRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var language = mapper.Map<Language>(request);
 
         context.Languages.Add(language);

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Commands;
@@ -5,10 +6,14 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
-public class DeleteHandler(SakilaContext context) : IRequestHandler<LanguageDeleteRequest, bool>
+public class DeleteHandler(
+    SakilaContext context,
+    IValidator<LanguageDeleteRequest> validator) : IRequestHandler<LanguageDeleteRequest, bool>
 {
     public async Task<bool> Handle(LanguageDeleteRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var language = await context.Languages.FirstAsync(l => l.LanguageId == request.Id, cancellationToken);
         context.Languages.Remove(language);
         await context.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Commands;
@@ -6,11 +7,16 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
-public class UpdateHandler(SakilaContext context, IMapper mapper)
+public class UpdateHandler(
+    SakilaContext context,
+    IMapper mapper,
+    IValidator<LanguageUpdateRequest> validator)
     : IRequestHandler<LanguageUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         var language = await context.Languages
             .FirstAsync(l => l.LanguageId == request.Id, cancellationToken);
 

--- a/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
+using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Queries;
@@ -8,12 +9,17 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Queries.Handlers;
 
-public class GetByIdHandler(SakilaContext context, IMapper mapper)
+public class GetByIdHandler(
+    SakilaContext context,
+    IMapper mapper,
+    IValidator<LanguageGetByIdRequest> validator)
     : IRequestHandler<LanguageGetByIdRequest, LanguageGetByIdResponse?>
 {
     public async Task<LanguageGetByIdResponse?> Handle(LanguageGetByIdRequest request,
         CancellationToken cancellationToken)
     {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
         return await context.Languages
             .Where(l => l.LanguageId == request.Id)
             .ProjectTo<LanguageGetByIdResponse>(mapper.ConfigurationProvider)


### PR DESCRIPTION
## Summary
- remove automatic validation pipeline and register validators manually
- invoke validators from each handler
- update README to mention in-handler validation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684221bdc834832e9e2e868aa98a6511