### PR TITLE
Refactor validators and update handlers

### DIFF
--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -1,8 +1,8 @@
 using AutoMapper;
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
@@ -15,10 +15,13 @@ public class UpdateHandler(
 {
     public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
     {
-        await validator.ValidateAndThrowAsync(request, cancellationToken);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            throw new ValidationException(validationResult.Errors);
+        }
 
-        var country = await context.Countries
-            .FirstAsync(c => c.CountryId == request.Id, cancellationToken);
+        var country = (Country)validationResult.RootContextData["country"];
 
         mapper.Map(request, country);
         await context.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Countries/Commands/Validators/CreateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CreateValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Validators;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
@@ -8,9 +9,9 @@ public class CreateValidator : AbstractValidator<CountryCreateRequest>
 {
     public CreateValidator(SakilaContext context)
     {
+        Include(new CountryCreateValidator());
+
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Country name is required.")
-            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.")
             .Must(name => !context.Countries.Any(c => c.Country1 == name))
             .WithMessage("A country with this name already exists.");
     }

--- a/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Validators;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
@@ -8,6 +9,8 @@ public class DeleteValidator : AbstractValidator<CountryDeleteRequest>
 {
     public DeleteValidator(SakilaContext context)
     {
+        Include(new CountryDeleteValidator());
+
         RuleFor(x => x.Id)
             .Must(id => context.Countries.Any(c => c.CountryId == id))
             .WithMessage("Country not found.");

--- a/Sakila.Application/Countries/Commands/Validators/UpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/UpdateValidator.cs
@@ -1,5 +1,8 @@
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Validators;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
@@ -8,10 +11,21 @@ public class UpdateValidator : AbstractValidator<CountryUpdateRequest>
 {
     public UpdateValidator(SakilaContext context)
     {
+        Include(new CountryUpdateValidator());
+
+        RuleFor(x => x.Id)
+            .MustAsync(async (cmd, id, ctx, ct) =>
+            {
+                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                if (country == null) return false;
+                ctx.RootContextData["country"] = country;
+                return true;
+            })
+            .WithMessage("Country not found.");
+
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Country name is required.")
-            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.")
-            .Must((cmd, name) => !context.Countries.Any(c => c.Country1 == name && c.CountryId != cmd.Id))
+            .MustAsync(async (cmd, name, _, ct) =>
+                !await context.Countries.AnyAsync(c => c.Country1 == name && c.CountryId != cmd.Id, ct))
             .WithMessage("Another country with this name already exists.");
     }
 }

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -1,8 +1,8 @@
 using AutoMapper;
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
@@ -15,10 +15,13 @@ public class UpdateHandler(
 {
     public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
     {
-        await validator.ValidateAndThrowAsync(request, cancellationToken);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            throw new ValidationException(validationResult.Errors);
+        }
 
-        var language = await context.Languages
-            .FirstAsync(l => l.LanguageId == request.Id, cancellationToken);
+        var language = (Language)validationResult.RootContextData["language"];
 
         mapper.Map(request, language);
         await context.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Languages/Commands/Validators/CreateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/CreateValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Contracts.Languages.Validators;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
@@ -8,9 +9,9 @@ public class CreateValidator : AbstractValidator<LanguageCreateRequest>
 {
     public CreateValidator(SakilaContext context)
     {
+        Include(new LanguageCreateValidator());
+
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Language name is required.")
-            .MaximumLength(20).WithMessage("Language name must be 20 characters or fewer.")
             .Must(name => !context.Languages.Any(l => l.Name == name))
             .WithMessage("A language with this name already exists.");
     }

--- a/Sakila.Application/Languages/Commands/Validators/DeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/DeleteValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Contracts.Languages.Validators;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
@@ -8,6 +9,8 @@ public class DeleteValidator : AbstractValidator<LanguageDeleteRequest>
 {
     public DeleteValidator(SakilaContext context)
     {
+        Include(new LanguageDeleteValidator());
+
         RuleFor(x => x.Id)
             .Must(id => context.Languages.Any(l => l.LanguageId == id))
             .WithMessage("Language not found.");

--- a/Sakila.Application/Languages/Commands/Validators/UpdateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/UpdateValidator.cs
@@ -1,5 +1,8 @@
 ﻿using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Contracts.Languages.Validators;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
@@ -8,11 +11,21 @@ public class UpdateValidator : AbstractValidator<LanguageUpdateRequest>
 {
     public UpdateValidator(SakilaContext context)
     {
+        Include(new LanguageUpdateValidator());
+
+        RuleFor(x => x.Id)
+            .MustAsync(async (cmd, id, ctx, ct) =>
+            {
+                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                if (language == null) return false;
+                ctx.RootContextData["language"] = language;
+                return true;
+            })
+            .WithMessage("Language not found.");
+
         RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("Language name is required.")
-            .MaximumLength(20).WithMessage("Language name must be 20 characters or fewer.")
-            .Must((cmd, name) =>
-                !context.Languages.Any(l => l.Name == name && l.LanguageId != cmd.Id))
+            .MustAsync(async (cmd, name, _, ct) =>
+                !await context.Languages.AnyAsync(l => l.Name == name && l.LanguageId != cmd.Id, ct))
             .WithMessage("Another language with this name already exists.");
     }
 }

--- a/Sakila.Contracts/Countries/Validators/CountryCreateValidator.cs
+++ b/Sakila.Contracts/Countries/Validators/CountryCreateValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+
+namespace Sakila.Contracts.Countries.Validators;
+
+public class CountryCreateValidator : AbstractValidator<CountryCreateRequest>
+{
+    public CountryCreateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Country name is required.")
+            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.");
+    }
+}

--- a/Sakila.Contracts/Countries/Validators/CountryDeleteValidator.cs
+++ b/Sakila.Contracts/Countries/Validators/CountryDeleteValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+
+namespace Sakila.Contracts.Countries.Validators;
+
+public class CountryDeleteValidator : AbstractValidator<CountryDeleteRequest>
+{
+    public CountryDeleteValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("Id must be greater than zero.");
+    }
+}

--- a/Sakila.Contracts/Countries/Validators/CountryUpdateValidator.cs
+++ b/Sakila.Contracts/Countries/Validators/CountryUpdateValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using Sakila.Contracts.Countries.Commands;
+
+namespace Sakila.Contracts.Countries.Validators;
+
+public class CountryUpdateValidator : AbstractValidator<CountryUpdateRequest>
+{
+    public CountryUpdateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Country name is required.")
+            .MaximumLength(50).WithMessage("Country name must be 50 characters or fewer.");
+    }
+}

--- a/Sakila.Contracts/Languages/Validators/LanguageCreateValidator.cs
+++ b/Sakila.Contracts/Languages/Validators/LanguageCreateValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using Sakila.Contracts.Languages.Commands;
+
+namespace Sakila.Contracts.Languages.Validators;
+
+public class LanguageCreateValidator : AbstractValidator<LanguageCreateRequest>
+{
+    public LanguageCreateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Language name is required.")
+            .MaximumLength(20).WithMessage("Language name must be 20 characters or fewer.");
+    }
+}

--- a/Sakila.Contracts/Languages/Validators/LanguageDeleteValidator.cs
+++ b/Sakila.Contracts/Languages/Validators/LanguageDeleteValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Sakila.Contracts.Languages.Commands;
+
+namespace Sakila.Contracts.Languages.Validators;
+
+public class LanguageDeleteValidator : AbstractValidator<LanguageDeleteRequest>
+{
+    public LanguageDeleteValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("Id must be greater than zero.");
+    }
+}

--- a/Sakila.Contracts/Languages/Validators/LanguageUpdateValidator.cs
+++ b/Sakila.Contracts/Languages/Validators/LanguageUpdateValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using Sakila.Contracts.Languages.Commands;
+
+namespace Sakila.Contracts.Languages.Validators;
+
+public class LanguageUpdateValidator : AbstractValidator<LanguageUpdateRequest>
+{
+    public LanguageUpdateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Language name is required.")
+            .MaximumLength(20).WithMessage("Language name must be 20 characters or fewer.");
+    }
+}

--- a/Sakila.Contracts/Sakila.Contracts.csproj
+++ b/Sakila.Contracts/Sakila.Contracts.csproj
@@ -67,6 +67,9 @@
     <Compile Include="Languages\Queries\LanguageGetByIdRequest.cs" />
     <Compile Include="Languages\Responses\LanguageGetAllResponse.cs" />
     <Compile Include="Languages\Responses\LanguageGetByIdResponse.cs" />
+    <Compile Include="Languages\Validators\LanguageCreateValidator.cs" />
+    <Compile Include="Languages\Validators\LanguageUpdateValidator.cs" />
+    <Compile Include="Languages\Validators\LanguageDeleteValidator.cs" />
     <Compile Include="Countries\Commands\CountryCreateRequest.cs" />
     <Compile Include="Countries\Commands\CountryDeleteRequest.cs" />
     <Compile Include="Countries\Commands\CountryUpdateRequest.cs" />
@@ -74,6 +77,9 @@
     <Compile Include="Countries\Queries\CountryGetByIdRequest.cs" />
     <Compile Include="Countries\Responses\CountryGetAllResponse.cs" />
     <Compile Include="Countries\Responses\CountryGetByIdResponse.cs" />
+    <Compile Include="Countries\Validators\CountryCreateValidator.cs" />
+    <Compile Include="Countries\Validators\CountryUpdateValidator.cs" />
+    <Compile Include="Countries\Validators\CountryDeleteValidator.cs" />
     <Compile Include="Services\ICountryService.cs" />
     <Compile Include="Services\ILanguageService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
## Summary
- add frontend validators in `Sakila.Contracts`
- extend backend validators to reuse contract validators
- fetch entities in backend validators and reuse them in Update handlers

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684225f67870832ea1854f3c94321429