### PR TITLE
Refactor handlers to reuse validated entities

### DIFF
--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -1,6 +1,6 @@
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
+using Sakila.Domain.Models;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Infrastructure.Data;
 
@@ -14,7 +14,8 @@ public class DeleteHandler(
     {
         await validator.ValidateAndThrowAsync(request, cancellationToken);
 
-        var country = await context.Countries.FirstAsync(c => c.CountryId == request.Id, cancellationToken);
+        var ctx = new ValidationContext<CountryDeleteRequest>(request);
+        var country = (Country)ctx.RootContextData["country"];
         context.Countries.Remove(country);
         await context.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/DeleteValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Validators;
 using Sakila.Infrastructure.Data;
@@ -12,7 +13,13 @@ public class DeleteValidator : AbstractValidator<CountryDeleteRequest>
         Include(new CountryDeleteValidator());
 
         RuleFor(x => x.Id)
-            .Must(id => context.Countries.Any(c => c.CountryId == id))
+            .MustAsync(async (_, id, ctx, ct) =>
+            {
+                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                if (country == null) return false;
+                ctx.RootContextData["country"] = country;
+                return true;
+            })
             .WithMessage("Country not found.");
     }
 }

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -1,8 +1,7 @@
 using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
+using Sakila.Domain.Models;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Countries.Responses;
 using Sakila.Infrastructure.Data;
@@ -20,9 +19,8 @@ public class GetByIdHandler(
     {
         await validator.ValidateAndThrowAsync(request, cancellationToken);
 
-        return await context.Countries
-            .Where(c => c.CountryId == request.Id)
-            .ProjectTo<CountryGetByIdResponse>(mapper.ConfigurationProvider)
-            .FirstOrDefaultAsync(cancellationToken);
+        var ctx = new ValidationContext<CountryGetByIdRequest>(request);
+        var country = (Country)ctx.RootContextData["country"];
+        return mapper.Map<CountryGetByIdResponse>(country);
     }
 }

--- a/Sakila.Application/Countries/Queries/Validators/GetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/GetByIdValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Infrastructure.Data;
 
@@ -9,7 +10,13 @@ public class GetByIdValidator : AbstractValidator<CountryGetByIdRequest>
     public GetByIdValidator(SakilaContext context)
     {
         RuleFor(x => x.Id)
-            .Must(id => context.Countries.Any(c => c.CountryId == id))
+            .MustAsync(async (_, id, ctx, ct) =>
+            {
+                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                if (country == null) return false;
+                ctx.RootContextData["country"] = country;
+                return true;
+            })
             .WithMessage("Country not found.");
     }
 }

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -1,6 +1,6 @@
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
+using Sakila.Domain.Models;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Infrastructure.Data;
 
@@ -14,7 +14,8 @@ public class DeleteHandler(
     {
         await validator.ValidateAndThrowAsync(request, cancellationToken);
 
-        var language = await context.Languages.FirstAsync(l => l.LanguageId == request.Id, cancellationToken);
+        var ctx = new ValidationContext<LanguageDeleteRequest>(request);
+        var language = (Language)ctx.RootContextData["language"];
         context.Languages.Remove(language);
         await context.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Languages/Commands/Validators/DeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/DeleteValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Validators;
 using Sakila.Infrastructure.Data;
@@ -12,7 +13,13 @@ public class DeleteValidator : AbstractValidator<LanguageDeleteRequest>
         Include(new LanguageDeleteValidator());
 
         RuleFor(x => x.Id)
-            .Must(id => context.Languages.Any(l => l.LanguageId == id))
+            .MustAsync(async (_, id, ctx, ct) =>
+            {
+                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                if (language == null) return false;
+                ctx.RootContextData["language"] = language;
+                return true;
+            })
             .WithMessage("Language not found.");
     }
 }

--- a/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
@@ -1,8 +1,7 @@
 using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using FluentValidation;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
+using Sakila.Domain.Models;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Contracts.Languages.Responses;
 using Sakila.Infrastructure.Data;
@@ -20,9 +19,8 @@ public class GetByIdHandler(
     {
         await validator.ValidateAndThrowAsync(request, cancellationToken);
 
-        return await context.Languages
-            .Where(l => l.LanguageId == request.Id)
-            .ProjectTo<LanguageGetByIdResponse>(mapper.ConfigurationProvider)
-            .FirstOrDefaultAsync(cancellationToken);
+        var ctx = new ValidationContext<LanguageGetByIdRequest>(request);
+        var language = (Language)ctx.RootContextData["language"];
+        return mapper.Map<LanguageGetByIdResponse>(language);
     }
 }

--- a/Sakila.Application/Languages/Queries/Validators/GetByIdValidator.cs
+++ b/Sakila.Application/Languages/Queries/Validators/GetByIdValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Infrastructure.Data;
 
@@ -9,7 +10,13 @@ public class GetByIdValidator : AbstractValidator<LanguageGetByIdRequest>
     public GetByIdValidator(SakilaContext context)
     {
         RuleFor(x => x.Id)
-            .Must(id => context.Languages.Any(l => l.LanguageId == id))
+            .MustAsync(async (_, id, ctx, ct) =>
+            {
+                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                if (language == null) return false;
+                ctx.RootContextData["language"] = language;
+                return true;
+            })
             .WithMessage("Language not found.");
     }
 }


### PR DESCRIPTION
## Summary
- update delete and get by id validators to store queried entities in `RootContextData`
- adjust delete handlers to reuse validated entities instead of querying again
- adjust get-by-id handlers to map from validated entities

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c1c3158832ea453ba16673b9641