### PR TITLE
Add client-side validation

### DIFF
--- a/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,10 @@
 ﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using FluentValidation;
 using Sakila.Contracts.Services;
+using Sakila.Contracts.Languages.Commands;
+using Sakila.Contracts.Languages.Validators;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Contracts.Countries.Validators;
 using Sakila.Web.Common;
 using Sakila.Web.Services;
 
@@ -12,6 +17,12 @@ public static class ServiceCollectionExtensions
         builder.Services.AddScoped<IApiClient, ApiClient>();
         builder.Services.AddScoped<ILanguageService, LanguageService>();
         builder.Services.AddScoped<ICountryService, CountryService>();
+        builder.Services.AddTransient<IValidator<LanguageCreateRequest>, LanguageCreateValidator>();
+        builder.Services.AddTransient<IValidator<LanguageUpdateRequest>, LanguageUpdateValidator>();
+        builder.Services.AddTransient<IValidator<LanguageDeleteRequest>, LanguageDeleteValidator>();
+        builder.Services.AddTransient<IValidator<CountryCreateRequest>, CountryCreateValidator>();
+        builder.Services.AddTransient<IValidator<CountryUpdateRequest>, CountryUpdateValidator>();
+        builder.Services.AddTransient<IValidator<CountryDeleteRequest>, CountryDeleteValidator>();
         builder.Services.AddScoped(sp => new HttpClient
             { BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"]!) });
         return builder;

--- a/Sakila.Web/Sakila.Web.csproj
+++ b/Sakila.Web/Sakila.Web.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sakila.Web/Services/CountryService.cs
+++ b/Sakila.Web/Services/CountryService.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Responses;
 using Sakila.Contracts.Services;
@@ -5,9 +6,16 @@ using Sakila.Web.Common;
 
 namespace Sakila.Web.Services;
 
-public class CountryService(IApiClient apiClient) : ICountryService
+public class CountryService(
+    IApiClient apiClient,
+    IValidator<CountryCreateRequest> createValidator,
+    IValidator<CountryUpdateRequest> updateValidator,
+    IValidator<CountryDeleteRequest> deleteValidator) : ICountryService
 {
     private readonly string _resource = "countries";
+    private readonly IValidator<CountryCreateRequest> _createValidator = createValidator;
+    private readonly IValidator<CountryUpdateRequest> _updateValidator = updateValidator;
+    private readonly IValidator<CountryDeleteRequest> _deleteValidator = deleteValidator;
 
     public async Task<CountryGetAllResponse> GetAllAsync()
     {
@@ -21,16 +29,20 @@ public class CountryService(IApiClient apiClient) : ICountryService
 
     public async Task CreateAsync(CountryCreateRequest request)
     {
+        await _createValidator.ValidateAndThrowAsync(request);
         await apiClient.PostAsync(_resource, request);
     }
 
     public async Task UpdateAsync(CountryUpdateRequest request)
     {
+        await _updateValidator.ValidateAndThrowAsync(request);
         await apiClient.PutAsync($"{_resource}/{request.Id}", request);
     }
 
     public async Task DeleteAsync(int id)
     {
+        var request = new CountryDeleteRequest { Id = id };
+        await _deleteValidator.ValidateAndThrowAsync(request);
         await apiClient.DeleteAsync($"{_resource}/{id}");
     }
 }

--- a/Sakila.Web/Services/LanguageService.cs
+++ b/Sakila.Web/Services/LanguageService.cs
@@ -1,13 +1,21 @@
-﻿using Sakila.Contracts.Languages.Commands;
+﻿using FluentValidation;
+using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Responses;
 using Sakila.Contracts.Services;
 using Sakila.Web.Common;
 
 namespace Sakila.Web.Services;
 
-public class LanguageService(IApiClient apiClient) : ILanguageService
+public class LanguageService(
+    IApiClient apiClient,
+    IValidator<LanguageCreateRequest> createValidator,
+    IValidator<LanguageUpdateRequest> updateValidator,
+    IValidator<LanguageDeleteRequest> deleteValidator) : ILanguageService
 {
     private readonly string _resource = "languages";
+    private readonly IValidator<LanguageCreateRequest> _createValidator = createValidator;
+    private readonly IValidator<LanguageUpdateRequest> _updateValidator = updateValidator;
+    private readonly IValidator<LanguageDeleteRequest> _deleteValidator = deleteValidator;
 
     public async Task<LanguageGetAllResponse> GetAllAsync()
     {
@@ -21,16 +29,20 @@ public class LanguageService(IApiClient apiClient) : ILanguageService
 
     public async Task CreateAsync(LanguageCreateRequest request)
     {
+        await _createValidator.ValidateAndThrowAsync(request);
         await apiClient.PostAsync(_resource, request);
     }
 
     public async Task UpdateAsync(LanguageUpdateRequest request)
     {
+        await _updateValidator.ValidateAndThrowAsync(request);
         await apiClient.PutAsync($"{_resource}/{request.Id}", request);
     }
 
     public async Task DeleteAsync(int id)
     {
+        var request = new LanguageDeleteRequest { Id = id };
+        await _deleteValidator.ValidateAndThrowAsync(request);
         await apiClient.DeleteAsync($"{_resource}/{id}");
     }
 }


### PR DESCRIPTION
## Summary
- register FluentValidation validators in front-end DI
- validate requests in `CountryService` and `LanguageService`
- add FluentValidation package to Blazor project

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842344329b0832e94623b38b3481d3d