### PR TITLE
Handle SQL errors and display general errors

### DIFF
--- a/Sakila.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Sakila.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 
 namespace Sakila.API.Middleware;
 
@@ -26,6 +28,38 @@ public class ExceptionHandlingMiddleware(RequestDelegate next)
                 Status = 400,
                 Title = "Validation failed",
                 Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"
+            };
+
+            var json = JsonSerializer.Serialize(problem);
+            await context.Response.WriteAsync(json);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is SqlException sqlEx)
+        {
+            context.Response.StatusCode = 500;
+            context.Response.ContentType = "application/problem+json";
+
+            var problem = new ProblemDetails
+            {
+                Status = 500,
+                Title = "A database error occurred.",
+                Detail = sqlEx.Message,
+                Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
+            };
+
+            var json = JsonSerializer.Serialize(problem);
+            await context.Response.WriteAsync(json);
+        }
+        catch (SqlException ex)
+        {
+            context.Response.StatusCode = 500;
+            context.Response.ContentType = "application/problem+json";
+
+            var problem = new ProblemDetails
+            {
+                Status = 500,
+                Title = "A database error occurred.",
+                Detail = ex.Message,
+                Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
             };
 
             var json = JsonSerializer.Serialize(problem);

--- a/Sakila.Contracts/Common/IApiResponse.cs
+++ b/Sakila.Contracts/Common/IApiResponse.cs
@@ -5,6 +5,7 @@ namespace Sakila.Contracts.Common;
 public interface IApiResponse<TResponse>
 {
     Dictionary<string, string[]> Errors { get; set; }
+    List<string> GeneralErrors { get; set; }
     bool IsSuccess { get; }
     TResponse? Data { get; set; }
 }

--- a/Sakila.Web/Common/ApiClient.cs
+++ b/Sakila.Web/Common/ApiClient.cs
@@ -23,6 +23,10 @@ public class ApiClient(HttpClient httpClient) : IApiClient
         {
             return new ApiResponse<TResponse>(exception.Errors);
         }
+        catch (HttpRequestException exception)
+        {
+            return new ApiResponse<TResponse>(exception.Message);
+        }
     }
 
     public async Task<IApiResponse<object>> PostAsync<TRequest>(string url, TRequest request,
@@ -42,6 +46,10 @@ public class ApiClient(HttpClient httpClient) : IApiClient
         catch (ApiValidationException exception)
         {
             return new ApiResponse<object>(exception.Errors);
+        }
+        catch (HttpRequestException exception)
+        {
+            return new ApiResponse<object>(exception.Message);
         }
     }
 
@@ -63,6 +71,10 @@ public class ApiClient(HttpClient httpClient) : IApiClient
         {
             return new ApiResponse<object>(exception.Errors);
         }
+        catch (HttpRequestException exception)
+        {
+            return new ApiResponse<object>(exception.Message);
+        }
     }
 
     public async Task<IApiResponse<object>> DeleteAsync(string url)
@@ -75,6 +87,10 @@ public class ApiClient(HttpClient httpClient) : IApiClient
         catch (ApiValidationException exception)
         {
             return new ApiResponse<object>(exception.Errors);
+        }
+        catch (HttpRequestException exception)
+        {
+            return new ApiResponse<object>(exception.Message);
         }
     }
 
@@ -96,9 +112,21 @@ public class ApiClient(HttpClient httpClient) : IApiClient
 
             if (problem?.Errors is { Count: > 0 })
                 throw new ApiValidationException(problem.Errors);
+            return new ApiResponse<TResponse>(problem?.ToString() ?? "Bad request");
         }
 
-        throw new HttpRequestException(
-            $"Unexpected status: {response.StatusCode}\n\n{await response.Content.ReadAsStringAsync()}");
+        var errorContent = await response.Content.ReadAsStringAsync();
+        try
+        {
+            var document = JsonSerializer.Deserialize<JsonElement>(errorContent, Options);
+            if (document.TryGetProperty("detail", out var detail))
+                return new ApiResponse<TResponse>(detail.GetString() ?? "An error occurred");
+        }
+        catch (JsonException)
+        {
+            // ignore
+        }
+
+        return new ApiResponse<TResponse>($"Unexpected status: {response.StatusCode}");
     }
 }

--- a/Sakila.Web/Common/ApiResponse.cs
+++ b/Sakila.Web/Common/ApiResponse.cs
@@ -11,6 +11,8 @@ public class ApiResponse<TResponse> : IApiResponse<TResponse>
 
     public ApiResponse(TResponse? data) => Data = data;
     public ApiResponse(Dictionary<string, string[]> errors) => Errors = errors;
+    public ApiResponse(string error) => GeneralErrors.Add(error);
+    public ApiResponse(IEnumerable<string> errors) => GeneralErrors.AddRange(errors);
 
     public ApiResponse(ValidationException exception)
     {
@@ -20,6 +22,7 @@ public class ApiResponse<TResponse> : IApiResponse<TResponse>
     }
 
     public Dictionary<string, string[]> Errors { get; set; } = new();
-    public bool IsSuccess => !Errors.Any();
+    public List<string> GeneralErrors { get; set; } = new();
+    public bool IsSuccess => !Errors.Any() && !GeneralErrors.Any();
     public TResponse? Data { get; set; }
 }

--- a/Sakila.Web/Pages/Components/GeneralErrors.razor
+++ b/Sakila.Web/Pages/Components/GeneralErrors.razor
@@ -1,0 +1,9 @@
+@if (Messages != null && Messages.Any())
+{
+    <div class="alert alert-danger">
+        @foreach (var message in Messages)
+        {
+            <div>@message</div>
+        }
+    </div>
+}

--- a/Sakila.Web/Pages/Components/GeneralErrors.razor.cs
+++ b/Sakila.Web/Pages/Components/GeneralErrors.razor.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Sakila.Web.Pages.Components;
+
+public partial class GeneralErrors
+{
+    [Parameter] public IEnumerable<string>? Messages { get; set; }
+}

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -1,3 +1,4 @@
+@using Sakila.Web.Pages.Components
 @if (Visible)
 {
     <div class="modal show d-block" tabindex="-1">
@@ -7,6 +8,7 @@
                     <h5 class="modal-title">Confirm Deletion</h5>
                 </div>
                 <div class="modal-body">
+                    <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     <p>Are you sure you want to delete <strong>@Country.Name</strong>?</p>
                 </div>
                 <div class="modal-footer">

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -7,7 +7,7 @@ public partial class ConfirmDelete
 {
     [Parameter] public bool Visible { get; set; }
     [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
-    [Parameter] public Dictionary<string, string[]> Errors { get; set; } = new();
+    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnConfirm { get; set; }
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
@@ -8,7 +8,8 @@
                     <h5 class="modal-title">@Title Country</h5>
                 </div>
                 <div class="modal-body">
-                    <FormTextInput @bind-Value="Country.Name" Label="Country Name" Field="Name" Errors="Errors"/>
+                    <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
+                    <FormTextInput @bind-Value="Country.Name" Label="Country Name" Field="Name" Errors="ApiResponse?.Errors"/>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-secondary" @onclick="OnCancel">Cancel</button>

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
@@ -7,7 +7,7 @@ public partial class CountryFormDialog
 {
     [Parameter] public bool Visible { get; set; }
     [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
-    [Parameter] public Dictionary<string, string[]> Errors { get; set; } = new();
+    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnSubmit { get; set; }
     private string Title => Country.Id != 0 ? "Edit" : "Add";

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -37,12 +37,12 @@ else
 
 <CountryFormDialog Visible="_isDialogOpen"
                    Country="_selectedCountry"
-                   Errors="_apiResponse.Errors"
+                   ApiResponse="_otherResponse"
                    OnCancel="CloseDialog"
                    OnSubmit="SubmitCountry"/>
 
 <ConfirmDelete Visible="_isDeleteDialogOpen"
                Country="_selectedCountry"
-               Errors="_apiResponse.Errors"
+               ApiResponse="_otherResponse"
                OnCancel="CloseDeleteDialog"
                OnConfirm="ConfirmDelete"/>

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -12,6 +12,7 @@ public partial class List
     private bool _isDeleteDialogOpen;
     private bool _isDialogOpen;
     private IApiResponse<CountryGetAllResponse> _apiResponse;
+    private IApiResponse<object>? _otherResponse;
     private CountryGetByIdResponse _selectedCountry = new();
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
@@ -31,6 +32,7 @@ public partial class List
                 Name = country.Name
             };
 
+        _otherResponse = null;
         _isDialogOpen = true;
     }
 
@@ -38,10 +40,12 @@ public partial class List
     {
         _isDialogOpen = false;
         _selectedCountry = new CountryGetByIdResponse();
+        _otherResponse = null;
     }
 
     private async Task SubmitCountry()
     {
+        _otherResponse = null;
         IApiResponse<object> apiResponse;
         if (_selectedCountry.Id == 0)
         {
@@ -54,6 +58,7 @@ public partial class List
             apiResponse = await CountryService.UpdateAsync(request);
         }
 
+        _otherResponse = apiResponse;
         if (apiResponse.IsSuccess)
         {
             await RefreshCountries();
@@ -70,17 +75,19 @@ public partial class List
     {
         _selectedCountry = country;
         _isDeleteDialogOpen = true;
+        _otherResponse = null;
     }
 
     private void CloseDeleteDialog()
     {
         _isDeleteDialogOpen = false;
+        _otherResponse = null;
     }
 
     private async Task ConfirmDelete()
     {
-        var apiResponse = await CountryService.DeleteAsync(_selectedCountry.Id);
-        if (apiResponse.IsSuccess)
+        _otherResponse = await CountryService.DeleteAsync(_selectedCountry.Id);
+        if (_otherResponse.IsSuccess)
         {
             await RefreshCountries();
             CloseDeleteDialog();

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -1,3 +1,4 @@
+@using Sakila.Web.Pages.Components
 ﻿@if (Visible)
 {
     <div class="modal show d-block" tabindex="-1">
@@ -7,6 +8,7 @@
                     <h5 class="modal-title">Confirm Deletion</h5>
                 </div>
                 <div class="modal-body">
+                    <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     <p>Are you sure you want to delete <strong>@Language.Name</strong>?</p>
                 </div>
                 <div class="modal-footer">

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -9,7 +9,6 @@ public partial class ConfirmDelete
     [Parameter] public bool Visible { get; set; }
     [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
     [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
-    // WE MUST HANDLE SERVER ERRORS
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnConfirm { get; set; }
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor
@@ -8,6 +8,7 @@
                     <h5 class="modal-title">@Title Language</h5>
                 </div>
                 <div class="modal-body">
+                    <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     <FormTextInput @bind-Value="Language.Name" Label="Language Name" Field="Name" Errors="ApiResponse?.Errors"/>
                 </div>
                 <div class="modal-footer">

--- a/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor.cs
@@ -9,7 +9,6 @@ public partial class LanguageFormDialog
     [Parameter] public bool Visible { get; set; }
     [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
     [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
-    // WE MUST HANDLE SERVER ERRORS
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnSubmit { get; set; }
     private string Title => Language.Id != 0 ? "Edit" : "Add";

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -31,6 +31,7 @@ public partial class List
                 Name = language.Name
             };
 
+        _otherResponse = null;
         _isDialogOpen = true;
     }
 
@@ -38,6 +39,7 @@ public partial class List
     {
         _isDialogOpen = false;
         _selectedLanguage = new LanguageGetByIdResponse();
+        _otherResponse = null;
     }
 
     private async Task SubmitLanguage()
@@ -69,11 +71,13 @@ public partial class List
     {
         _selectedLanguage = language;
         _isDeleteDialogOpen = true;
+        _otherResponse = null;
     }
 
     private void CloseDeleteDialog()
     {
         _isDeleteDialogOpen = false;
+        _otherResponse = null;
     }
 
     private async Task ConfirmDelete()


### PR DESCRIPTION
## Summary
- catch database exceptions in API middleware
- track general errors in API responses
- handle HTTP and server errors in Blazor API client
- show general errors in country and language dialogs
- add reusable `GeneralErrors` component

## Testing
- `dotnet build CRUD-DSC.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a1895f44832ea2ddd7f215419b27