### PR TITLE
Refactor handlers to use typed validators

### DIFF
--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ using Sakila.Application.Languages.Commands.Handlers;
 using Sakila.Application.Languages.Commands.Validators;
 using Sakila.Application.Languages.Queries.Mapping;
 using Sakila.Application.Languages.Queries.Validators;
+using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Languages.Commands;
@@ -45,14 +47,14 @@ public static class ServiceCollectionExtensions
             .AddAutoMapper(typeof(GetByIdProfile).Assembly);
 
         services.AddTransient<IValidator<LanguageCreateRequest>, LanguageCreateValidator>();
-        services.AddTransient<IValidator<LanguageUpdateRequest>, LanguageUpdateValidator>();
-        services.AddTransient<IValidator<LanguageDeleteRequest>, LanguageDeleteValidator>();
-        services.AddTransient<IValidator<LanguageGetByIdRequest>, LanguageGetByIdValidator>();
+        services.AddTransient<IValidatorFork<LanguageUpdateRequest, Language>, LanguageUpdateValidator>();
+        services.AddTransient<IValidatorFork<LanguageDeleteRequest, Language>, LanguageDeleteValidator>();
+        services.AddTransient<IValidatorFork<LanguageGetByIdRequest, Language>, LanguageGetByIdValidator>();
 
         services.AddTransient<IValidator<CountryCreateRequest>, CountryCreateValidator>();
-        services.AddTransient<IValidator<CountryUpdateRequest>, CountryUpdateValidator>();
-        services.AddTransient<IValidator<CountryDeleteRequest>, CountryDeleteValidator>();
-        services.AddTransient<IValidator<CountryGetByIdRequest>, CountryGetByIdValidator>();
+        services.AddTransient<IValidatorFork<CountryUpdateRequest, Country>, CountryUpdateValidator>();
+        services.AddTransient<IValidatorFork<CountryDeleteRequest, Country>, CountryDeleteValidator>();
+        services.AddTransient<IValidatorFork<CountryGetByIdRequest, Country>, CountryGetByIdValidator>();
 
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(c =>

--- a/Sakila.Application/Common/Validation/ValidatorFork.cs
+++ b/Sakila.Application/Common/Validation/ValidatorFork.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace Sakila.Application.Common.Validation;
+
+/// <summary>
+/// Allows validators to store entities in the <see cref="ValidationContext{T}"/>
+/// so handlers can retrieve them after validation completes.
+/// </summary>
+/// <typeparam name="TRequest">Request type being validated.</typeparam>
+/// <typeparam name="TData">Type of the entity loaded during validation.</typeparam>
+public interface IValidatorFork<TRequest, TData> : IValidator<TRequest>
+{
+    /// <summary>
+    /// Retrieves the stored entity from the given validation context.
+    /// </summary>
+    /// <param name="context">Validation context used during validation.</param>
+    /// <returns>The entity if found; otherwise <c>null</c>.</returns>
+    TData? GetData(ValidationContext<TRequest> context);
+}
+
+/// <inheritdoc/>
+public abstract class ValidatorFork<TRequest, TData> : AbstractValidator<TRequest>, IValidatorFork<TRequest, TData>
+{
+    private readonly string _dataKey = $"{typeof(TRequest).FullName}:{typeof(TData).FullName}";
+
+    protected void SetData(ValidationContext<TRequest> context, TData data)
+        => context.RootContextData[_dataKey] = data!;
+
+    public TData? GetData(ValidationContext<TRequest> context)
+        => context.RootContextData.TryGetValue(_dataKey, out var value) ? (TData?)value : default;
+}

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -2,13 +2,14 @@ using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class DeleteHandler(
     SakilaContext context,
-    IValidator<CountryDeleteRequest> validator) : IRequestHandler<CountryDeleteRequest, bool>
+    IValidatorFork<CountryDeleteRequest, Country> validator) : IRequestHandler<CountryDeleteRequest, bool>
 {
     public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
     {
@@ -17,7 +18,7 @@ public class DeleteHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var country = (Country)validationContext.RootContextData["country"];
+        var country = validator.GetData(validationContext)!;
         context.Countries.Remove(country);
         await context.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
@@ -10,7 +11,7 @@ namespace Sakila.Application.Countries.Commands.Handlers;
 public class UpdateHandler(
     SakilaContext context,
     IMapper mapper,
-    IValidator<CountryUpdateRequest> validator)
+    IValidatorFork<CountryUpdateRequest, Country> validator)
     : IRequestHandler<CountryUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
@@ -20,7 +21,7 @@ public class UpdateHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var country = (Country)validationContext.RootContextData["country"];
+        var country = validator.GetData(validationContext)!;
 
         mapper.Map(request, country);
         await context.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
+using Sakila.Application.Common.Validation;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
-public class CountryDeleteValidator : AbstractValidator<CountryDeleteRequest>
+public class CountryDeleteValidator : ValidatorFork<CountryDeleteRequest, Country>
 {
     public CountryDeleteValidator(SakilaContext context)
     {
@@ -14,7 +16,7 @@ public class CountryDeleteValidator : AbstractValidator<CountryDeleteRequest>
             {
                 var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
-                ctx.RootContextData["country"] = country;
+                SetData(ctx, country);
                 return true;
             })
             .WithMessage("Country not found.");

--- a/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
-public class CountryUpdateValidator : AbstractValidator<CountryUpdateRequest>
+public class CountryUpdateValidator : ValidatorFork<CountryUpdateRequest, Country>
 {
     public CountryUpdateValidator(SakilaContext context)
     {
@@ -16,13 +18,13 @@ public class CountryUpdateValidator : AbstractValidator<CountryUpdateRequest>
             {
                 var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
-                ctx.RootContextData["country"] = country;
+                SetData(ctx, country);
                 return true;
             })
             .WithMessage("Country not found.");
 
         RuleFor(x => x.Name)
-            .MustAsync(async (request, name, _, ct) =>
+            .MustAsync(async (request, name, ctx, ct) =>
                 !await context.Countries.AnyAsync(c => c.Country1 == name && c.CountryId != request.Id, ct))
             .WithMessage("Another country with this name already exists.");
     }

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -4,6 +4,7 @@ using MediatR;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Handlers;
@@ -11,7 +12,7 @@ namespace Sakila.Application.Countries.Queries.Handlers;
 public class GetByIdHandler(
     SakilaContext context,
     IMapper mapper,
-    IValidator<CountryGetByIdRequest> validator)
+    IValidatorFork<CountryGetByIdRequest, Country> validator)
     : IRequestHandler<CountryGetByIdRequest, CountryGetByIdResponse?>
 {
     public async Task<CountryGetByIdResponse?> Handle(CountryGetByIdRequest request,
@@ -22,7 +23,7 @@ public class GetByIdHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var country = (Country)validationContext.RootContextData["country"];
+        var country = validator.GetData(validationContext)!;
         return mapper.Map<CountryGetByIdResponse>(country);
     }
 }

--- a/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Queries;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Validators;
 
-public class CountryGetByIdValidator : AbstractValidator<CountryGetByIdRequest>
+public class CountryGetByIdValidator : ValidatorFork<CountryGetByIdRequest, Country>
 {
     public CountryGetByIdValidator(SakilaContext context)
     {
@@ -14,7 +16,7 @@ public class CountryGetByIdValidator : AbstractValidator<CountryGetByIdRequest>
             {
                 var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
-                ctx.RootContextData["country"] = country;
+                SetData(ctx, country);
                 return true;
             })
             .WithMessage("Country not found.");

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -2,13 +2,14 @@ using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class DeleteHandler(
     SakilaContext dbContext,
-    IValidator<LanguageDeleteRequest> validator) : IRequestHandler<LanguageDeleteRequest, bool>
+    IValidatorFork<LanguageDeleteRequest, Language> validator) : IRequestHandler<LanguageDeleteRequest, bool>
 {
     public async Task<bool> Handle(LanguageDeleteRequest request, CancellationToken cancellationToken)
     {
@@ -17,7 +18,7 @@ public class DeleteHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var language = (Language)validationContext.RootContextData["language"];
+        var language = validator.GetData(validationContext)!;
         dbContext.Languages.Remove(language);
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using MediatR;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
@@ -10,7 +11,7 @@ namespace Sakila.Application.Languages.Commands.Handlers;
 public class UpdateHandler(
     SakilaContext context,
     IMapper mapper,
-    IValidator<LanguageUpdateRequest> validator)
+    IValidatorFork<LanguageUpdateRequest, Language> validator)
     : IRequestHandler<LanguageUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
@@ -20,7 +21,7 @@ public class UpdateHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var language = (Language)validationContext.RootContextData["language"];
+        var language = validator.GetData(validationContext)!;
         mapper.Map(request, language);
         await context.SaveChangesAsync(cancellationToken);
 

--- a/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
-public class LanguageDeleteValidator : AbstractValidator<LanguageDeleteRequest>
+public class LanguageDeleteValidator : ValidatorFork<LanguageDeleteRequest, Language>
 {
     public LanguageDeleteValidator(SakilaContext context)
     {
@@ -14,7 +16,7 @@ public class LanguageDeleteValidator : AbstractValidator<LanguageDeleteRequest>
             {
                 var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                ctx.RootContextData["language"] = language;
+                SetData(ctx, language);
                 return true;
             })
             .WithMessage("Language not found.");

--- a/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
-public class LanguageUpdateValidator : AbstractValidator<LanguageUpdateRequest>
+public class LanguageUpdateValidator : ValidatorFork<LanguageUpdateRequest, Language>
 {
     public LanguageUpdateValidator(SakilaContext context)
     {
@@ -16,13 +18,13 @@ public class LanguageUpdateValidator : AbstractValidator<LanguageUpdateRequest>
             {
                 var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                ctx.RootContextData["language"] = language;
+                SetData(ctx, language);
                 return true;
             })
             .WithMessage("Language not found.");
 
         RuleFor(x => x.Name)
-            .MustAsync(async (cmd, name, _, ct) =>
+            .MustAsync(async (cmd, name, ctx, ct) =>
                 !await context.Languages.AnyAsync(l => l.Name == name && l.LanguageId != cmd.Id, ct))
             .WithMessage("Another language with this name already exists.");
     }

--- a/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
@@ -4,12 +4,13 @@ using MediatR;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Validation;
 
 namespace Sakila.Application.Languages.Queries.Handlers;
 
 public class GetByIdHandler(
     IMapper mapper,
-    IValidator<LanguageGetByIdRequest> validator)
+    IValidatorFork<LanguageGetByIdRequest, Language> validator)
     : IRequestHandler<LanguageGetByIdRequest, LanguageGetByIdResponse?>
 {
     public async Task<LanguageGetByIdResponse?> Handle(LanguageGetByIdRequest request,
@@ -20,7 +21,7 @@ public class GetByIdHandler(
 
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
-        var language = (Language)validationContext.RootContextData["language"];
+        var language = validator.GetData(validationContext)!;
         return mapper.Map<LanguageGetByIdResponse>(language);
     }
 }

--- a/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
+++ b/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
@@ -1,11 +1,13 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Queries;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Queries.Validators;
 
-public class LanguageGetByIdValidator : AbstractValidator<LanguageGetByIdRequest>
+public class LanguageGetByIdValidator : ValidatorFork<LanguageGetByIdRequest, Language>
 {
     public LanguageGetByIdValidator(SakilaContext context)
     {
@@ -14,7 +16,7 @@ public class LanguageGetByIdValidator : AbstractValidator<LanguageGetByIdRequest
             {
                 var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                ctx.RootContextData["language"] = language;
+                SetData(ctx, language);
                 return true;
             })
             .WithMessage("Language not found.");


### PR DESCRIPTION
## Summary
- inject `IValidatorFork` into handlers to retrieve loaded entities without casts
- register typed validators in API service configuration

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457fcb07c8832e84cc43aca544310c