### PR TITLE
Rename SakilaContext parameter to dbContext

### DIFF
--- a/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
@@ -8,7 +8,7 @@ using Sakila.Infrastructure.Data;
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class CreateHandler(
-    SakilaContext context,
+    SakilaContext dbContext,
     IMapper mapper,
     IValidator<CountryCreateRequest> validator) : IRequestHandler<CountryCreateRequest, int>
 {
@@ -18,8 +18,8 @@ public class CreateHandler(
 
         var country = mapper.Map<Country>(request);
 
-        context.Countries.Add(country);
-        await context.SaveChangesAsync(cancellationToken);
+        dbContext.Countries.Add(country);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return country.CountryId;
     }

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -8,7 +8,7 @@ using Sakila.Infrastructure.Data;
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class DeleteHandler(
-    SakilaContext context,
+    SakilaContext dbContext,
     IValidatorWithData<CountryDeleteRequest, Country> validator) : IRequestHandler<CountryDeleteRequest, bool>
 {
     public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
@@ -19,8 +19,8 @@ public class DeleteHandler(
         if (!result.IsValid) throw new ValidationException(result.Errors);
 
         var country = validator.GetData(validationContext);
-        context.Countries.Remove(country);
-        await context.SaveChangesAsync(cancellationToken);
+        dbContext.Countries.Remove(country);
+        await dbContext.SaveChangesAsync(cancellationToken);
         return true;
     }
 }

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -9,7 +9,7 @@ using Sakila.Infrastructure.Data;
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class UpdateHandler(
-    SakilaContext context,
+    SakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<CountryUpdateRequest, Country> validator)
     : IRequestHandler<CountryUpdateRequest, Unit>
@@ -24,7 +24,7 @@ public class UpdateHandler(
         var country = validator.GetData(validationContext);
 
         mapper.Map(request, country);
-        await context.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;
     }

--- a/Sakila.Application/Countries/Commands/Validators/CountryCreateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryCreateValidator.cs
@@ -6,12 +6,12 @@ namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryCreateValidator : AbstractValidator<CountryCreateRequest>
 {
-    public CountryCreateValidator(SakilaContext context)
+    public CountryCreateValidator(SakilaContext dbContext)
     {
         Include(new Contracts.Countries.Commands.Validators.CountryCreateValidator());
 
         RuleFor(x => x.Name)
-            .Must(name => !context.Countries.Any(c => c.Country1 == name))
+            .Must(name => !dbContext.Countries.Any(c => c.Country1 == name))
             .WithMessage("A country with this name already exists.");
     }
 }

--- a/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
@@ -9,12 +9,12 @@ namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryDeleteValidator : ValidatorWithData<CountryDeleteRequest, Country>
 {
-    public CountryDeleteValidator(SakilaContext context)
+    public CountryDeleteValidator(SakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>
             {
-                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                var country = await dbContext.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
                 SetData(ctx, country);
                 return true;

--- a/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
@@ -9,14 +9,14 @@ namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, Country>
 {
-    public CountryUpdateValidator(SakilaContext context)
+    public CountryUpdateValidator(SakilaContext dbContext)
     {
         Include(new Contracts.Countries.Commands.Validators.CountryUpdateValidator());
 
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>
             {
-                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                var country = await dbContext.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
                 SetData(ctx, country);
                 return true;
@@ -25,7 +25,7 @@ public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, Co
 
         RuleFor(x => x.Name)
             .MustAsync(async (request, name, ctx, ct) =>
-                !await context.Countries.AnyAsync(c => c.Country1 == name && c.CountryId != request.Id, ct))
+                !await dbContext.Countries.AnyAsync(c => c.Country1 == name && c.CountryId != request.Id, ct))
             .WithMessage("Another country with this name already exists.");
     }
 }

--- a/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
@@ -7,7 +7,7 @@ using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Handlers;
 
-public class GetAllHandler(SakilaContext context, IMapper mapper)
+public class GetAllHandler(SakilaContext dbContext, IMapper mapper)
     : IRequestHandler<CountryGetAllRequest, CountryGetAllResponse>
 {
     public async Task<CountryGetAllResponse> Handle(CountryGetAllRequest request,
@@ -15,7 +15,7 @@ public class GetAllHandler(SakilaContext context, IMapper mapper)
     {
         return new CountryGetAllResponse
         {
-            Countries = await mapper.ProjectTo<CountryGetByIdResponse>(context.Countries)
+            Countries = await mapper.ProjectTo<CountryGetByIdResponse>(dbContext.Countries)
                 .ToListAsync(cancellationToken)
         };
     }

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -10,7 +10,7 @@ using Sakila.Infrastructure.Data;
 namespace Sakila.Application.Countries.Queries.Handlers;
 
 public class GetByIdHandler(
-    SakilaContext context,
+    SakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<CountryGetByIdRequest, Country> validator)
     : IRequestHandler<CountryGetByIdRequest, CountryGetByIdResponse?>

--- a/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
@@ -9,12 +9,12 @@ namespace Sakila.Application.Countries.Queries.Validators;
 
 public class CountryGetByIdValidator : ValidatorWithData<CountryGetByIdRequest, Country>
 {
-    public CountryGetByIdValidator(SakilaContext context)
+    public CountryGetByIdValidator(SakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>
             {
-                var country = await context.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
+                var country = await dbContext.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
                 SetData(ctx, country);
                 return true;

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -9,7 +9,7 @@ using Sakila.Infrastructure.Data;
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class UpdateHandler(
-    SakilaContext context,
+    SakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<LanguageUpdateRequest, Language> validator)
     : IRequestHandler<LanguageUpdateRequest, Unit>
@@ -23,7 +23,7 @@ public class UpdateHandler(
 
         var language = validator.GetData(validationContext);
         mapper.Map(request, language);
-        await context.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;
     }

--- a/Sakila.Application/Languages/Commands/Validators/LanguageCreateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageCreateValidator.cs
@@ -6,12 +6,12 @@ namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageCreateValidator : AbstractValidator<LanguageCreateRequest>
 {
-    public LanguageCreateValidator(SakilaContext context)
+    public LanguageCreateValidator(SakilaContext dbContext)
     {
         Include(new Contracts.Languages.Commands.Validators.LanguageCreateValidator());
 
         RuleFor(x => x.Name)
-            .Must(name => !context.Languages.Any(l => l.Name == name))
+            .Must(name => !dbContext.Languages.Any(l => l.Name == name))
             .WithMessage("A language with this name already exists.");
     }
 }

--- a/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
@@ -9,12 +9,12 @@ namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageDeleteValidator : ValidatorWithData<LanguageDeleteRequest, Language>
 {
-    public LanguageDeleteValidator(SakilaContext context)
+    public LanguageDeleteValidator(SakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>
             {
-                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
                 SetData(ctx, language);
                 return true;

--- a/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
@@ -9,14 +9,14 @@ namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, Language>
 {
-    public LanguageUpdateValidator(SakilaContext context)
+    public LanguageUpdateValidator(SakilaContext dbContext)
     {
         Include(new Contracts.Languages.Commands.Validators.LanguageUpdateValidator());
 
         RuleFor(x => x.Id)
             .MustAsync(async (cmd, id, ctx, ct) =>
             {
-                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
                 SetData(ctx, language);
                 return true;
@@ -25,7 +25,7 @@ public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, 
 
         RuleFor(x => x.Name)
             .MustAsync(async (cmd, name, ctx, ct) =>
-                !await context.Languages.AnyAsync(l => l.Name == name && l.LanguageId != cmd.Id, ct))
+                !await dbContext.Languages.AnyAsync(l => l.Name == name && l.LanguageId != cmd.Id, ct))
             .WithMessage("Another language with this name already exists.");
     }
 }

--- a/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
+++ b/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
@@ -9,12 +9,12 @@ namespace Sakila.Application.Languages.Queries.Validators;
 
 public class LanguageGetByIdValidator : ValidatorWithData<LanguageGetByIdRequest, Language>
 {
-    public LanguageGetByIdValidator(SakilaContext context)
+    public LanguageGetByIdValidator(SakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>
             {
-                var language = await context.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
+                var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
                 SetData(ctx, language);
                 return true;


### PR DESCRIPTION
## Summary
- standardize variable names for SakilaContext parameters
- update validators and handlers accordingly

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845886f6d54832eb11bf41c48394086