### PR TITLE
Add ValidateAndGetDataAsync

### DIFF
--- a/Sakila.Application/Common/Validation/IValidatorWithData.cs
+++ b/Sakila.Application/Common/Validation/IValidatorWithData.cs
@@ -3,6 +3,9 @@ using FluentValidation;
 namespace Sakila.Application.Common.Validation;
 
 public interface IValidatorWithData<TRequest, out TData> : IValidator<TRequest>
-{
+{ 
     TData GetData(ValidationContext<TRequest> context);
+
+    Task<TData> ValidateAndGetDataAsync(TRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/Sakila.Application/Common/Validation/ValidatorWithData.cs
+++ b/Sakila.Application/Common/Validation/ValidatorWithData.cs
@@ -16,4 +16,15 @@ public abstract class ValidatorWithData<TRequest, TData> : AbstractValidator<TRe
     {
         context.RootContextData[_dataKey] = data!;
     }
+
+    public async Task<TData> ValidateAndGetDataAsync(TRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var context = new ValidationContext<TRequest>(request);
+        var result = await ValidateAsync(context, cancellationToken);
+
+        if (!result.IsValid) throw new ValidationException(result.Errors);
+
+        return GetData(context);
+    }
 }

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -1,4 +1,3 @@
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
@@ -13,12 +12,7 @@ public class DeleteHandler(
 {
     public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<CountryDeleteRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var country = validator.GetData(validationContext);
+        var country = await validator.ValidateAndGetDataAsync(request, cancellationToken);
         dbContext.Countries.Remove(country);
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
@@ -16,12 +15,7 @@ public class UpdateHandler(
 {
     public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<CountryUpdateRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var country = validator.GetData(validationContext);
+        var country = await validator.ValidateAndGetDataAsync(request, cancellationToken);
 
         mapper.Map(request, country);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Queries;
@@ -18,12 +17,7 @@ public class GetByIdHandler(
     public async Task<CountryGetByIdResponse?> Handle(CountryGetByIdRequest request,
         CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<CountryGetByIdRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var country = validator.GetData(validationContext);
+        var country = await validator.ValidateAndGetDataAsync(request, cancellationToken);
         return mapper.Map<CountryGetByIdResponse>(country);
     }
 }

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -1,4 +1,3 @@
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
@@ -13,12 +12,7 @@ public class DeleteHandler(
 {
     public async Task<bool> Handle(LanguageDeleteRequest request, CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<LanguageDeleteRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var language = validator.GetData(validationContext);
+        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
         dbContext.Languages.Remove(language);
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
@@ -16,12 +15,7 @@ public class UpdateHandler(
 {
     public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<LanguageUpdateRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var language = validator.GetData(validationContext);
+        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
         mapper.Map(request, language);
         await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentValidation;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Queries;
@@ -16,12 +15,7 @@ public class GetByIdHandler(
     public async Task<LanguageGetByIdResponse?> Handle(LanguageGetByIdRequest request,
         CancellationToken cancellationToken)
     {
-        var validationContext = new ValidationContext<LanguageGetByIdRequest>(request);
-        var result = await validator.ValidateAsync(validationContext, cancellationToken);
-
-        if (!result.IsValid) throw new ValidationException(result.Errors);
-
-        var language = validator.GetData(validationContext);
+        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
         return mapper.Map<LanguageGetByIdResponse>(language);
     }
 }


### PR DESCRIPTION
## Summary
- add `ValidateAndGetDataAsync` to `IValidatorWithData` and `ValidatorWithData`
- refactor command and query handlers to use new helper method
- clean up unused usings

## Testing
- `dotnet build CRUD-DSC.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458a711074832e969730b492840ab7