### PR TITLE
Add validator data dtos for validators with data

### DIFF
--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,9 @@ using Sakila.API.Options;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators;
 using Sakila.Application.Countries.Commands.Validators.Data;
+using Sakila.Application.Countries.Queries.Validators.Data;
+using Sakila.Application.Languages.Commands.Validators.Data;
+using Sakila.Application.Languages.Queries.Validators.Data;
 using Sakila.Application.Countries.Queries.Validators;
 using Sakila.Application.Languages.Commands.Handlers;
 using Sakila.Application.Languages.Commands.Validators;
@@ -15,7 +18,6 @@ using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries;
-using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.API.Extensions;
@@ -48,15 +50,15 @@ public static class ServiceCollectionExtensions
             .AddAutoMapper(typeof(GetByIdProfile).Assembly);
 
         services.AddTransient<IValidator<LanguageCreateRequest>, LanguageCreateValidator>();
-        services.AddTransient<IValidatorWithData<LanguageUpdateRequest, Language>, LanguageUpdateValidator>();
-        services.AddTransient<IValidatorWithData<LanguageDeleteRequest, Language>, LanguageDeleteValidator>();
-        services.AddTransient<IValidatorWithData<LanguageGetByIdRequest, Language>, LanguageGetByIdValidator>();
+        services.AddTransient<IValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData>, LanguageUpdateValidator>();
+        services.AddTransient<IValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData>, LanguageDeleteValidator>();
+        services.AddTransient<IValidatorWithData<LanguageGetByIdRequest, LanguageGetByIdValidatorData>, LanguageGetByIdValidator>();
 
         services.AddTransient<IValidator<CountryCreateRequest>, CountryCreateValidator>();
-        services.AddTransient<IValidatorWithData<CountryUpdateRequest, Country>, CountryUpdateValidator>();
+        services.AddTransient<IValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData>, CountryUpdateValidator>();
         services.AddTransient<IValidatorWithData<CountryDeleteRequest, CountryDeleteValidatorData>,
             CountryDeleteValidator>();
-        services.AddTransient<IValidatorWithData<CountryGetByIdRequest, Country>, CountryGetByIdValidator>();
+        services.AddTransient<IValidatorWithData<CountryGetByIdRequest, CountryGetByIdValidatorData>, CountryGetByIdValidator>();
 
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(c =>

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -2,7 +2,7 @@ using AutoMapper;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
-using Sakila.Domain.Models;
+using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
@@ -10,14 +10,14 @@ namespace Sakila.Application.Countries.Commands.Handlers;
 public class UpdateHandler(
     SakilaContext dbContext,
     IMapper mapper,
-    IValidatorWithData<CountryUpdateRequest, Country> validator)
+    IValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData> validator)
     : IRequestHandler<CountryUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
     {
-        var country = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
 
-        mapper.Map(request, country);
+        mapper.Map(request, data.Country);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
@@ -3,11 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
-public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, Country>
+public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData>
 {
     public CountryUpdateValidator(SakilaContext dbContext)
     {
@@ -18,7 +19,7 @@ public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, Co
             {
                 var country = await dbContext.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
-                SetData(ctx, country);
+                SetData(ctx, new CountryUpdateValidatorData(country));
                 return true;
             })
             .WithMessage("Country not found.");

--- a/Sakila.Application/Countries/Commands/Validators/Data/CountryUpdateValidatorData.cs
+++ b/Sakila.Application/Countries/Commands/Validators/Data/CountryUpdateValidatorData.cs
@@ -1,0 +1,8 @@
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Countries.Commands.Validators.Data;
+
+public class CountryUpdateValidatorData(Country country)
+{
+    public Country Country { get; set; } = country;
+}

--- a/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetByIdHandler.cs
@@ -3,7 +3,7 @@ using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Countries.Queries.Responses;
-using Sakila.Domain.Models;
+using Sakila.Application.Countries.Queries.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Handlers;
@@ -11,13 +11,13 @@ namespace Sakila.Application.Countries.Queries.Handlers;
 public class GetByIdHandler(
     SakilaContext dbContext,
     IMapper mapper,
-    IValidatorWithData<CountryGetByIdRequest, Country> validator)
+    IValidatorWithData<CountryGetByIdRequest, CountryGetByIdValidatorData> validator)
     : IRequestHandler<CountryGetByIdRequest, CountryGetByIdResponse?>
 {
     public async Task<CountryGetByIdResponse?> Handle(CountryGetByIdRequest request,
         CancellationToken cancellationToken)
     {
-        var country = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        return mapper.Map<CountryGetByIdResponse>(country);
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        return mapper.Map<CountryGetByIdResponse>(data.Country);
     }
 }

--- a/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
@@ -3,11 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Domain.Models;
+using Sakila.Application.Countries.Queries.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Queries.Validators;
 
-public class CountryGetByIdValidator : ValidatorWithData<CountryGetByIdRequest, Country>
+public class CountryGetByIdValidator : ValidatorWithData<CountryGetByIdRequest, CountryGetByIdValidatorData>
 {
     public CountryGetByIdValidator(SakilaContext dbContext)
     {
@@ -16,7 +17,7 @@ public class CountryGetByIdValidator : ValidatorWithData<CountryGetByIdRequest, 
             {
                 var country = await dbContext.Countries.FirstOrDefaultAsync(c => c.CountryId == id, ct);
                 if (country == null) return false;
-                SetData(ctx, country);
+                SetData(ctx, new CountryGetByIdValidatorData(country));
                 return true;
             })
             .WithMessage("Country not found.");

--- a/Sakila.Application/Countries/Queries/Validators/Data/CountryGetByIdValidatorData.cs
+++ b/Sakila.Application/Countries/Queries/Validators/Data/CountryGetByIdValidatorData.cs
@@ -1,0 +1,8 @@
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Countries.Queries.Validators.Data;
+
+public class CountryGetByIdValidatorData(Country country)
+{
+    public Country Country { get; set; } = country;
+}

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -1,19 +1,19 @@
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
-using Sakila.Domain.Models;
+using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class DeleteHandler(
     SakilaContext dbContext,
-    IValidatorWithData<LanguageDeleteRequest, Language> validator) : IRequestHandler<LanguageDeleteRequest, bool>
+    IValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData> validator) : IRequestHandler<LanguageDeleteRequest, bool>
 {
     public async Task<bool> Handle(LanguageDeleteRequest request, CancellationToken cancellationToken)
     {
-        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        dbContext.Languages.Remove(language);
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        dbContext.Languages.Remove(data.Language);
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;
     }

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -2,7 +2,7 @@ using AutoMapper;
 using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
-using Sakila.Domain.Models;
+using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
@@ -10,13 +10,13 @@ namespace Sakila.Application.Languages.Commands.Handlers;
 public class UpdateHandler(
     SakilaContext dbContext,
     IMapper mapper,
-    IValidatorWithData<LanguageUpdateRequest, Language> validator)
+    IValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData> validator)
     : IRequestHandler<LanguageUpdateRequest, Unit>
 {
     public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
     {
-        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        mapper.Map(request, language);
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        mapper.Map(request, data.Language);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/Sakila.Application/Languages/Commands/Validators/Data/LanguageDeleteValidatorData.cs
+++ b/Sakila.Application/Languages/Commands/Validators/Data/LanguageDeleteValidatorData.cs
@@ -1,0 +1,8 @@
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Languages.Commands.Validators.Data;
+
+public class LanguageDeleteValidatorData(Language language)
+{
+    public Language Language { get; set; } = language;
+}

--- a/Sakila.Application/Languages/Commands/Validators/Data/LanguageUpdateValidatorData.cs
+++ b/Sakila.Application/Languages/Commands/Validators/Data/LanguageUpdateValidatorData.cs
@@ -1,0 +1,8 @@
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Languages.Commands.Validators.Data;
+
+public class LanguageUpdateValidatorData(Language language)
+{
+    public Language Language { get; set; } = language;
+}

--- a/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
@@ -3,11 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
-public class LanguageDeleteValidator : ValidatorWithData<LanguageDeleteRequest, Language>
+public class LanguageDeleteValidator : ValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData>
 {
     public LanguageDeleteValidator(SakilaContext dbContext)
     {
@@ -16,7 +17,7 @@ public class LanguageDeleteValidator : ValidatorWithData<LanguageDeleteRequest, 
             {
                 var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                SetData(ctx, language);
+                SetData(ctx, new LanguageDeleteValidatorData(language));
                 return true;
             })
             .WithMessage("Language not found.");

--- a/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
@@ -3,11 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
+using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
-public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, Language>
+public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData>
 {
     public LanguageUpdateValidator(SakilaContext dbContext)
     {
@@ -18,7 +19,7 @@ public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, 
             {
                 var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                SetData(ctx, language);
+                SetData(ctx, new LanguageUpdateValidatorData(language));
                 return true;
             })
             .WithMessage("Language not found.");

--- a/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetByIdHandler.cs
@@ -3,19 +3,19 @@ using MediatR;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Contracts.Languages.Queries.Responses;
-using Sakila.Domain.Models;
+using Sakila.Application.Languages.Queries.Validators.Data;
 
 namespace Sakila.Application.Languages.Queries.Handlers;
 
 public class GetByIdHandler(
     IMapper mapper,
-    IValidatorWithData<LanguageGetByIdRequest, Language> validator)
+    IValidatorWithData<LanguageGetByIdRequest, LanguageGetByIdValidatorData> validator)
     : IRequestHandler<LanguageGetByIdRequest, LanguageGetByIdResponse?>
 {
     public async Task<LanguageGetByIdResponse?> Handle(LanguageGetByIdRequest request,
         CancellationToken cancellationToken)
     {
-        var language = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        return mapper.Map<LanguageGetByIdResponse>(language);
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        return mapper.Map<LanguageGetByIdResponse>(data.Language);
     }
 }

--- a/Sakila.Application/Languages/Queries/Validators/Data/LanguageGetByIdValidatorData.cs
+++ b/Sakila.Application/Languages/Queries/Validators/Data/LanguageGetByIdValidatorData.cs
@@ -1,0 +1,8 @@
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Languages.Queries.Validators.Data;
+
+public class LanguageGetByIdValidatorData(Language language)
+{
+    public Language Language { get; set; } = language;
+}

--- a/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
+++ b/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
@@ -3,11 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Domain.Models;
+using Sakila.Application.Languages.Queries.Validators.Data;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Queries.Validators;
 
-public class LanguageGetByIdValidator : ValidatorWithData<LanguageGetByIdRequest, Language>
+public class LanguageGetByIdValidator : ValidatorWithData<LanguageGetByIdRequest, LanguageGetByIdValidatorData>
 {
     public LanguageGetByIdValidator(SakilaContext dbContext)
     {
@@ -16,7 +17,7 @@ public class LanguageGetByIdValidator : ValidatorWithData<LanguageGetByIdRequest
             {
                 var language = await dbContext.Languages.FirstOrDefaultAsync(l => l.LanguageId == id, ct);
                 if (language == null) return false;
-                SetData(ctx, language);
+                SetData(ctx, new LanguageGetByIdValidatorData(language));
                 return true;
             })
             .WithMessage("Language not found.");


### PR DESCRIPTION
## Summary
- create `ValidatorData` classes for languages and countries
- wire validators and handlers to use the new data classes
- register updated validators in DI

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845914e7824832ea0eea145bec0fbac