### PR TITLE
Refactor front-end abstractions

### DIFF
--- a/Sakila.Contracts/Sakila.Contracts.csproj
+++ b/Sakila.Contracts/Sakila.Contracts.csproj
@@ -60,7 +60,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Common\IApiResponse.cs" />
     <Compile Include="Languages\Commands\LanguageCreateRequest.cs" />
     <Compile Include="Languages\Commands\LanguageDeleteRequest.cs" />
     <Compile Include="Languages\Commands\LanguageUpdateRequest.cs" />
@@ -79,8 +78,6 @@
     <Compile Include="Countries\Queries\Responses\CountryGetByIdResponse.cs" />
     <Compile Include="Countries\Commands\Validators\CountryCreateValidator.cs" />
     <Compile Include="Countries\Commands\Validators\CountryUpdateValidator.cs" />
-    <Compile Include="Services\ICountryService.cs" />
-    <Compile Include="Services\ILanguageService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/Sakila.Web/Abstractions/IApiClient.cs
+++ b/Sakila.Web/Abstractions/IApiClient.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 
-namespace Sakila.Web.Common;
+namespace Sakila.Web.Abstractions;
 
 public interface IApiClient
 {

--- a/Sakila.Web/Abstractions/IApiResponse.cs
+++ b/Sakila.Web/Abstractions/IApiResponse.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Sakila.Contracts.Common;
+namespace Sakila.Web.Abstractions;
 
 public interface IApiResponse<TResponse>
 {

--- a/Sakila.Web/Abstractions/ICountryService.cs
+++ b/Sakila.Web/Abstractions/ICountryService.cs
@@ -1,9 +1,9 @@
 using System.Threading.Tasks;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 
-namespace Sakila.Contracts.Services;
+namespace Sakila.Web.Abstractions;
 
 public interface ICountryService
 {

--- a/Sakila.Web/Abstractions/ILanguageService.cs
+++ b/Sakila.Web/Abstractions/ILanguageService.cs
@@ -1,9 +1,9 @@
 using System.Threading.Tasks;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 
-namespace Sakila.Contracts.Services;
+namespace Sakila.Web.Abstractions;
 
 public interface ILanguageService
 {

--- a/Sakila.Web/Common/ApiClient.cs
+++ b/Sakila.Web/Common/ApiClient.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentValidation;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 
 namespace Sakila.Web.Common;
 

--- a/Sakila.Web/Common/ApiResponse.cs
+++ b/Sakila.Web/Common/ApiResponse.cs
@@ -1,5 +1,5 @@
 using FluentValidation;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 
 namespace Sakila.Web.Common;
 

--- a/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
@@ -4,9 +4,9 @@ using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Commands.Validators;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Commands.Validators;
-using Sakila.Contracts.Services;
+using Sakila.Web.Abstractions;
 using Sakila.Web.Common;
-using Sakila.Web.Services;
+using Sakila.Web.Services.Implementations;
 
 namespace Sakila.Web.Extensions;
 

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Countries.Queries.Responses;
 
 namespace Sakila.Web.Pages.Countries.Components;

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Countries.Queries.Responses;
 
 namespace Sakila.Web.Pages.Countries.Components;

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -1,8 +1,7 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
-using Sakila.Contracts.Services;
 
 namespace Sakila.Web.Pages.Countries;
 

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Languages.Queries.Responses;
 
 namespace Sakila.Web.Pages.Languages.Components;

--- a/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Languages.Queries.Responses;
 
 namespace Sakila.Web.Pages.Languages.Components;

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -1,8 +1,7 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
-using Sakila.Contracts.Services;
 
 namespace Sakila.Web.Pages.Languages;
 

--- a/Sakila.Web/Services/Implementations/CountryService.cs
+++ b/Sakila.Web/Services/Implementations/CountryService.cs
@@ -1,11 +1,10 @@
 using FluentValidation;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
-using Sakila.Contracts.Services;
 using Sakila.Web.Common;
 
-namespace Sakila.Web.Services;
+namespace Sakila.Web.Services.Implementations;
 
 public class CountryService(
     IApiClient apiClient,

--- a/Sakila.Web/Services/Implementations/LanguageService.cs
+++ b/Sakila.Web/Services/Implementations/LanguageService.cs
@@ -1,11 +1,10 @@
 using FluentValidation;
-using Sakila.Contracts.Common;
+using Sakila.Web.Abstractions;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
-using Sakila.Contracts.Services;
 using Sakila.Web.Common;
 
-namespace Sakila.Web.Services;
+namespace Sakila.Web.Services.Implementations;
 
 public class LanguageService(
     IApiClient apiClient,


### PR DESCRIPTION
## Summary
- move IApiResponse and service interfaces out of `Sakila.Contracts`
- add new `Abstractions` folder in `Sakila.Web`
- separate service implementations under `Services/Implementations`
- update DI registration and components

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459d865d4c832ea7950bcab253c107