### PR TITLE
Enable sensitive logging only in development

### DIFF
--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.OpenApi.Models;
 using Sakila.API.Middleware;
 using Sakila.API.Options;
@@ -29,7 +30,8 @@ public static class ServiceCollectionExtensions
     private const string AppVersion = "v1";
 
     public static void AddApplicationLayer(this IServiceCollection services,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IWebHostEnvironment environment)
     {
         var webOptions = configuration.GetSection("App.Web").Get<AppWebOptions>()!;
         services.AddCors(options =>
@@ -41,8 +43,10 @@ public static class ServiceCollectionExtensions
 
         services.AddDbContext<SakilaContext>(options =>
         {
-            options.UseSqlServer(configuration.GetConnectionString("DefaultConnection"))
-                .EnableSensitiveDataLogging().LogTo(Console.WriteLine, LogLevel.Information);
+            options.UseSqlServer(configuration.GetConnectionString("DefaultConnection"));
+            if (environment.IsDevelopment())
+                options.EnableSensitiveDataLogging()
+                    .LogTo(Console.WriteLine, LogLevel.Information);
         });
 
         services.AddMediatR(serviceConfiguration =>

--- a/Sakila.API/Program.cs
+++ b/Sakila.API/Program.cs
@@ -3,7 +3,7 @@ using Sakila.API.Extensions;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-builder.Services.AddApplicationLayer(builder.Configuration);
+builder.Services.AddApplicationLayer(builder.Configuration, builder.Environment);
 
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- inject `IWebHostEnvironment` into `AddApplicationLayer`
- enable EF Core sensitive logging only in development
- update `Program.cs` to pass environment argument

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ba9628a8832e979519bc1af69c3a