### PR TITLE
Add Bootstrap via LibMan

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ La solución está organizada siguiendo los principios de **Clean Architecture**
 ## 🚀 Cómo ejecutar el proyecto
 
 1. Clona el repositorio
-2. Ejecutar en orden los scripts `01_sql-server-sakila-schema.sql` y `02_sql-server-sakila-insert-data.sql` del directorio `database/` en SQL Server para la creación de la base de datos Sakila
-3. Configura la cadena de conexión a tu base de datos Sakila en `appsettings.json`
-4. Ejecuta `Sakila.API` (API)
-5. Ejecuta `Sakila.Web` (cliente Razor)
-6. Navega a `/films`, `/cities`, etc. para interactuar con el sistema
+2. Ejecuta `libman restore` dentro de `Sakila.Web` para descargar Bootstrap y otras librerías
+3. Ejecutar en orden los scripts `01_sql-server-sakila-schema.sql` y `02_sql-server-sakila-insert-data.sql` del directorio `database/` en SQL Server para la creación de la base de datos Sakila
+4. Configura la cadena de conexión a tu base de datos Sakila en `appsettings.json`
+5. Ejecuta `Sakila.API` (API)
+6. Ejecuta `Sakila.Web` (cliente Razor)
+7. Navega a `/films`, `/cities`, etc. para interactuar con el sistema
 
 ---
 

--- a/Sakila.Web/Sakila.Web.csproj
+++ b/Sakila.Web/Sakila.Web.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sakila.Web/libman.json
+++ b/Sakila.Web/libman.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0",
+  "defaultProvider": "jsdelivr",
+  "libraries": [
+    {
+      "library": "bootstrap@5.3.2",
+      "destination": "wwwroot/lib/bootstrap/",
+      "files": [
+        "dist/css/bootstrap.min.css",
+        "dist/css/bootstrap.min.css.map",
+        "dist/js/bootstrap.bundle.min.js",
+        "dist/js/bootstrap.bundle.min.js.map"
+      ]
+    }
+  ]
+}

--- a/Sakila.Web/wwwroot/index.html
+++ b/Sakila.Web/wwwroot/index.html
@@ -26,7 +26,8 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
-<script src="_framework/blazor.webassembly.js"></script>
+    <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- configure LibMan to pull Bootstrap 5.3.2
- load bootstrap script in `index.html`
- restore libraries automatically via LibraryManager.Build
- update README with `libman restore` instructions

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bee011d4832eb1e74a1411cdb948