### PR TITLE
Refactor command handlers with generics

### DIFF
--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Models;
 using Sakila.API.Middleware;
 using Sakila.API.Options;
 using Sakila.Application.Common.Validation;
+using Sakila.Application.Common.Handlers;
 using Sakila.Application.Countries.Commands.Validators;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Application.Countries.Queries.Validators;
@@ -50,7 +51,7 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddMediatR(serviceConfiguration =>
-                serviceConfiguration.RegisterServicesFromAssembly(typeof(CreateHandler).Assembly))
+                serviceConfiguration.RegisterServicesFromAssembly(typeof(CreateHandlerBase<,,>).Assembly))
             .AddAutoMapper(typeof(GetByIdProfile).Assembly);
 
         services.AddTransient<IValidator<LanguageCreateRequest>, LanguageCreateValidator>();

--- a/Sakila.Application/Common/Handlers/CreateHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/CreateHandlerBase.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using FluentValidation;
+using MediatR;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Common.Handlers;
+
+public abstract class CreateHandlerBase<TRequest, TEntity, TResponse>(
+    SakilaContext dbContext,
+    IMapper mapper,
+    IValidator<TRequest> validator) : IRequestHandler<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    protected abstract TResponse GetResponse(TEntity entity);
+
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        await validator.ValidateAndThrowAsync(request, cancellationToken);
+
+        var entity = mapper.Map<TEntity>(request);
+        dbContext.Set<TEntity>().Add(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return GetResponse(entity);
+    }
+}

--- a/Sakila.Application/Common/Handlers/DeleteHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/DeleteHandlerBase.cs
@@ -1,0 +1,22 @@
+using MediatR;
+using Sakila.Application.Common.Validation;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Common.Handlers;
+
+public abstract class DeleteHandlerBase<TRequest, TEntity, TData>(
+    SakilaContext dbContext,
+    IValidatorWithData<TRequest, TData> validator) : IRequestHandler<TRequest, bool>
+    where TRequest : IRequest<bool>
+{
+    protected abstract TEntity GetData(TData data);
+
+    public async Task<bool> Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        var entity = GetData(data);
+        dbContext.Set<TEntity>().Remove(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/Sakila.Application/Common/Handlers/UpdateHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/UpdateHandlerBase.cs
@@ -1,0 +1,24 @@
+using AutoMapper;
+using MediatR;
+using Sakila.Application.Common.Validation;
+using Sakila.Infrastructure.Data;
+
+namespace Sakila.Application.Common.Handlers;
+
+public abstract class UpdateHandlerBase<TRequest, TEntity, TData>(
+    SakilaContext dbContext,
+    IMapper mapper,
+    IValidatorWithData<TRequest, TData> validator) : IRequestHandler<TRequest, Unit>
+    where TRequest : IRequest<Unit>
+{
+    protected abstract TEntity GetData(TData data);
+
+    public async Task<Unit> Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
+        var entity = GetData(data);
+        mapper.Map(request, entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentValidation;
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
@@ -10,17 +11,8 @@ namespace Sakila.Application.Countries.Commands.Handlers;
 public class CreateHandler(
     SakilaContext dbContext,
     IMapper mapper,
-    IValidator<CountryCreateRequest> validator) : IRequestHandler<CountryCreateRequest, int>
+    IValidator<CountryCreateRequest> validator) :
+    CreateHandlerBase<CountryCreateRequest, Country, int>(dbContext, mapper, validator)
 {
-    public async Task<int> Handle(CountryCreateRequest request, CancellationToken cancellationToken)
-    {
-        await validator.ValidateAndThrowAsync(request, cancellationToken);
-
-        var country = mapper.Map<Country>(request);
-
-        dbContext.Countries.Add(country);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return country.CountryId;
-    }
+    protected override int GetResponse(Country entity) => entity.CountryId;
 }

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
@@ -9,13 +11,7 @@ namespace Sakila.Application.Countries.Commands.Handlers;
 public class DeleteHandler(
     SakilaContext dbContext,
     IValidatorWithData<CountryDeleteRequest, CountryDeleteValidatorData> validator)
-    : IRequestHandler<CountryDeleteRequest, bool>
+    : DeleteHandlerBase<CountryDeleteRequest, Country, CountryDeleteValidatorData>(dbContext, validator)
 {
-    public async Task<bool> Handle(CountryDeleteRequest request, CancellationToken cancellationToken)
-    {
-        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        dbContext.Countries.Remove(data.Country);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return true;
-    }
+    protected override Country GetData(CountryDeleteValidatorData data) => data.Country;
 }

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -1,8 +1,10 @@
 using AutoMapper;
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
@@ -11,15 +13,7 @@ public class UpdateHandler(
     SakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData> validator)
-    : IRequestHandler<CountryUpdateRequest, Unit>
+    : UpdateHandlerBase<CountryUpdateRequest, Country, CountryUpdateValidatorData>(dbContext, mapper, validator)
 {
-    public async Task<Unit> Handle(CountryUpdateRequest request, CancellationToken cancellationToken)
-    {
-        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-
-        mapper.Map(request, data.Country);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
-    }
+    protected override Country GetData(CountryUpdateValidatorData data) => data.Country;
 }

--- a/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentValidation;
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
@@ -11,17 +12,7 @@ public class CreateHandler(
     SakilaContext dbContext,
     IMapper mapper,
     IValidator<LanguageCreateRequest> validator)
-    : IRequestHandler<LanguageCreateRequest, int>
+    : CreateHandlerBase<LanguageCreateRequest, Language, int>(dbContext, mapper, validator)
 {
-    public async Task<int> Handle(LanguageCreateRequest request, CancellationToken cancellationToken)
-    {
-        await validator.ValidateAndThrowAsync(request, cancellationToken);
-
-        var language = mapper.Map<Language>(request);
-
-        dbContext.Languages.Add(language);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return language.LanguageId;
-    }
+    protected override int GetResponse(Language entity) => entity.LanguageId;
 }

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
@@ -9,13 +11,7 @@ namespace Sakila.Application.Languages.Commands.Handlers;
 public class DeleteHandler(
     SakilaContext dbContext,
     IValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData> validator)
-    : IRequestHandler<LanguageDeleteRequest, bool>
+    : DeleteHandlerBase<LanguageDeleteRequest, Language, LanguageDeleteValidatorData>(dbContext, validator)
 {
-    public async Task<bool> Handle(LanguageDeleteRequest request, CancellationToken cancellationToken)
-    {
-        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        dbContext.Languages.Remove(data.Language);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return true;
-    }
+    protected override Language GetData(LanguageDeleteValidatorData data) => data.Language;
 }

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -1,8 +1,10 @@
 using AutoMapper;
 using MediatR;
+using Sakila.Application.Common.Handlers;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
+using Sakila.Domain.Models;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
@@ -11,14 +13,7 @@ public class UpdateHandler(
     SakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData> validator)
-    : IRequestHandler<LanguageUpdateRequest, Unit>
+    : UpdateHandlerBase<LanguageUpdateRequest, Language, LanguageUpdateValidatorData>(dbContext, mapper, validator)
 {
-    public async Task<Unit> Handle(LanguageUpdateRequest request, CancellationToken cancellationToken)
-    {
-        var data = await validator.ValidateAndGetDataAsync(request, cancellationToken);
-        mapper.Map(request, data.Language);
-        await dbContext.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
-    }
+    protected override Language GetData(LanguageUpdateValidatorData data) => data.Language;
 }


### PR DESCRIPTION
## Summary
- add abstract handler bases for create, update and delete
- refactor language and country handlers to inherit these bases
- register MediatR using the new generic base class
- rename `GetEntity` method to `GetData`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b23fd34832e82a720f29933e964