### PR TITLE
Use AsNoTracking in query handlers

### DIFF
--- a/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
@@ -15,7 +15,7 @@ public class GetAllHandler(SakilaContext dbContext, IMapper mapper)
     {
         return new CountryGetAllResponse
         {
-            Countries = await mapper.ProjectTo<CountryGetByIdResponse>(dbContext.Countries)
+            Countries = await mapper.ProjectTo<CountryGetByIdResponse>(dbContext.Countries.AsNoTracking())
                 .ToListAsync(cancellationToken)
         };
     }

--- a/Sakila.Application/Languages/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetAllHandler.cs
@@ -15,7 +15,7 @@ public class GetAllHandler(SakilaContext dbContext, IMapper mapper)
     {
         return new LanguageGetAllResponse
         {
-            Languages = await mapper.ProjectTo<LanguageGetByIdResponse>(dbContext.Languages)
+            Languages = await mapper.ProjectTo<LanguageGetByIdResponse>(dbContext.Languages.AsNoTracking())
                 .ToListAsync(cancellationToken)
         };
     }


### PR DESCRIPTION
## Summary
- avoid tracking when reading languages and countries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684992e85300832e8f4918080fd3e1ac