### PR TITLE
Refactor forms to use EditForm and validation

### DIFF
--- a/Sakila.Contracts/Countries/Queries/Responses/CountryGetByIdResponse.cs
+++ b/Sakila.Contracts/Countries/Queries/Responses/CountryGetByIdResponse.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Sakila.Contracts.Countries.Queries.Responses;
 
 public class CountryGetByIdResponse
 {
     public int Id { get; init; }
-    public string Name { get; set; } = null!;
+
+    [Required(ErrorMessage = "Country name is required.")]
+    [MaxLength(50, ErrorMessage = "Country name must be 50 characters or fewer.")]
+    public string Name { get; set; } = string.Empty;
 }

--- a/Sakila.Contracts/Languages/Queries/Responses/LanguageGetByIdResponse.cs
+++ b/Sakila.Contracts/Languages/Queries/Responses/LanguageGetByIdResponse.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Sakila.Contracts.Languages.Queries.Responses;
 
 public class LanguageGetByIdResponse
 {
     public int Id { get; init; }
-    public string Name { get; set; } = null!;
+
+    [Required(ErrorMessage = "Language name is required.")]
+    [MaxLength(20, ErrorMessage = "Language name must be 20 characters or fewer.")]
+    public string Name { get; set; } = string.Empty;
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryFormDialog.razor
@@ -4,17 +4,21 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">@Title Country</h5>
-                </div>
-                <div class="modal-body">
-                    <FormTextInput @bind-Value="Country.Name" Label="Country Name" Field="Name" Errors="ApiResponse?.Errors"/>
-                    <GeneralErrors Messages="ApiResponse?.GeneralErrors"/>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                    <button class="btn btn-primary" @onclick="OnSubmit">@Title</button>
-                </div>
+                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                    <div class="modal-header">
+                        <h5 class="modal-title">@Title Country</h5>
+                    </div>
+                    <div class="modal-body">
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name" />
+                        <ValidationMessage For="@(() => Country.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                        <button type="submit" class="btn btn-primary">@Title</button>
+                    </div>
+                </EditForm>
             </div>
         </div>
     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageFormDialog.razor
@@ -4,17 +4,21 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">@Title Language</h5>
-                </div>
-                <div class="modal-body">
-                    <FormTextInput @bind-Value="Language.Name" Label="Language Name" Field="Name" Errors="ApiResponse?.Errors"/>
-                    <GeneralErrors Messages="ApiResponse?.GeneralErrors"/>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                    <button class="btn btn-primary" @onclick="OnSubmit">@Title</button>
-                </div>
+                <EditForm Model="Language" OnValidSubmit="OnSubmit">
+                    <div class="modal-header">
+                        <h5 class="modal-title">@Title Language</h5>
+                    </div>
+                    <div class="modal-body">
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name" />
+                        <ValidationMessage For="@(() => Language.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                        <button type="submit" class="btn btn-primary">@Title</button>
+                    </div>
+                </EditForm>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- use DataAnnotations on response models
- update CountryFormDialog to use EditForm, InputText, and ValidationMessage
- update LanguageFormDialog similarly

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684999c02914832e9a2996b78b844255