### PR TITLE
Refactor error handling with ProblemDetails

### DIFF
--- a/Sakila.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Sakila.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,18 +1,20 @@
-using System.Text.Json;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 namespace Sakila.API.Middleware;
 
-public class ExceptionHandlingMiddleware(RequestDelegate next)
+public class ExceptionHandlingMiddleware(RequestDelegate next, ProblemDetailsFactory problemDetailsFactory)
 {
+    private readonly RequestDelegate _next = next;
+    private readonly ProblemDetailsFactory _problemDetailsFactory = problemDetailsFactory;
     public async Task InvokeAsync(HttpContext context)
     {
         try
         {
-            await next(context);
+            await _next(context);
         }
         catch (ValidationException ex)
         {
@@ -20,66 +22,55 @@ public class ExceptionHandlingMiddleware(RequestDelegate next)
                 .GroupBy(e => e.PropertyName)
                 .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
 
-            context.Response.StatusCode = 400;
-            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
 
-            var problem = new ValidationProblemDetails(errors)
-            {
-                Status = 400,
-                Title = "Validation failed",
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"
-            };
+            var problem = _problemDetailsFactory.CreateValidationProblemDetails(
+                context,
+                errors,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Validation failed",
+                type: "https://tools.ietf.org/html/rfc7231#section-6.5.1");
 
-            var json = JsonSerializer.Serialize(problem);
-            await context.Response.WriteAsync(json);
+            await context.Response.WriteAsJsonAsync(problem);
         }
         catch (DbUpdateException ex) when (ex.InnerException is SqlException sqlEx)
         {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
-            var problem = new ProblemDetails
-            {
-                Status = 500,
-                Title = "A database error occurred.",
-                Detail = sqlEx.Message,
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
-            };
+            var problem = _problemDetailsFactory.CreateProblemDetails(
+                context,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "A database error occurred.",
+                detail: sqlEx.Message,
+                type: "https://tools.ietf.org/html/rfc7231#section-6.6.1");
 
-            var json = JsonSerializer.Serialize(problem);
-            await context.Response.WriteAsync(json);
+            await context.Response.WriteAsJsonAsync(problem);
         }
         catch (SqlException ex)
         {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
-            var problem = new ProblemDetails
-            {
-                Status = 500,
-                Title = "A database error occurred.",
-                Detail = ex.Message,
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
-            };
+            var problem = _problemDetailsFactory.CreateProblemDetails(
+                context,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "A database error occurred.",
+                detail: ex.Message,
+                type: "https://tools.ietf.org/html/rfc7231#section-6.6.1");
 
-            var json = JsonSerializer.Serialize(problem);
-            await context.Response.WriteAsync(json);
+            await context.Response.WriteAsJsonAsync(problem);
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
-            var problem = new ProblemDetails
-            {
-                Status = 500,
-                Title = "An internal server error occurred.",
-                Detail = ex.Message,
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
-            };
+            var problem = _problemDetailsFactory.CreateProblemDetails(
+                context,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "An internal server error occurred.",
+                detail: ex.Message,
+                type: "https://tools.ietf.org/html/rfc7231#section-6.6.1");
 
-            var json = JsonSerializer.Serialize(problem);
-            await context.Response.WriteAsync(json);
+            await context.Response.WriteAsJsonAsync(problem);
         }
     }
 }

--- a/Sakila.Web/Common/ApiClient.cs
+++ b/Sakila.Web/Common/ApiClient.cs
@@ -103,24 +103,21 @@ public class ApiClient(HttpClient httpClient) : IApiClient
             return new ApiResponse<TResponse>(JsonSerializer.Deserialize<TResponse>(content, Options)!);
         }
 
-        if (response.StatusCode == HttpStatusCode.BadRequest)
-        {
-            var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync();
 
-            // Try to parse validation error structure
-            var problem = JsonSerializer.Deserialize<ValidationErrorResponse>(content, Options);
-
-            if (problem?.Errors is { Count: > 0 })
-                throw new ApiValidationException(problem.Errors);
-            return new ApiResponse<TResponse>(problem?.ToString() ?? "Bad request");
-        }
-
-        var errorContent = await response.Content.ReadAsStringAsync();
         try
         {
-            var document = JsonSerializer.Deserialize<JsonElement>(errorContent, Options);
+            var document = JsonSerializer.Deserialize<JsonElement>(content, Options);
+
+            if (response.StatusCode == HttpStatusCode.BadRequest && document.TryGetProperty("errors", out var errorsElement))
+            {
+                var errors = JsonSerializer.Deserialize<Dictionary<string, string[]>>(errorsElement.GetRawText(), Options)
+                             ?? new Dictionary<string, string[]>();
+                throw new ApiValidationException(errors);
+            }
+
             if (document.TryGetProperty("detail", out var detail))
-                return new ApiResponse<TResponse>(detail.GetString() ?? "An error occurred");
+                return new ApiResponse<TResponse>(detail.GetString() ?? $"Unexpected status: {response.StatusCode}");
         }
         catch (JsonException)
         {

--- a/Sakila.Web/Common/ValidationErrorResponse.cs
+++ b/Sakila.Web/Common/ValidationErrorResponse.cs
@@ -1,6 +1,0 @@
-namespace Sakila.Web.Common;
-
-public class ValidationErrorResponse
-{
-    public Dictionary<string, string[]> Errors { get; init; } = new();
-}


### PR DESCRIPTION
## Summary
- enhance `ExceptionHandlingMiddleware` with `ProblemDetailsFactory`
- serialize error responses using `CreateProblemDetails`
- parse standard `ProblemDetails` payloads in the `ApiClient`
- remove obsolete `ValidationErrorResponse` helper

## Testing
- `dotnet build CRUD-DSC.sln -v quiet` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68499c6ba8c0832e99d4c292ecce0eb3