### PR TITLE
Split form dialogs

### DIFF
--- a/Sakila.Contracts/Countries/Commands/CountryCreateRequest.cs
+++ b/Sakila.Contracts/Countries/Commands/CountryCreateRequest.cs
@@ -1,8 +1,11 @@
 using MediatR;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sakila.Contracts.Countries.Commands;
 
 public class CountryCreateRequest : IRequest<int>
 {
+    [Required(ErrorMessage = "Country name is required.")]
+    [MaxLength(50, ErrorMessage = "Country name must be 50 characters or fewer.")]
     public string Name { get; init; } = string.Empty;
 }

--- a/Sakila.Contracts/Countries/Commands/CountryUpdateRequest.cs
+++ b/Sakila.Contracts/Countries/Commands/CountryUpdateRequest.cs
@@ -1,9 +1,12 @@
 using MediatR;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sakila.Contracts.Countries.Commands;
 
 public class CountryUpdateRequest : IRequest<Unit>
 {
     public int Id { get; init; }
+    [Required(ErrorMessage = "Country name is required.")]
+    [MaxLength(50, ErrorMessage = "Country name must be 50 characters or fewer.")]
     public string Name { get; init; } = string.Empty;
 }

--- a/Sakila.Contracts/Countries/Queries/Responses/CountryGetByIdResponse.cs
+++ b/Sakila.Contracts/Countries/Queries/Responses/CountryGetByIdResponse.cs
@@ -1,12 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace Sakila.Contracts.Countries.Queries.Responses;
 
 public class CountryGetByIdResponse
 {
     public int Id { get; init; }
 
-    [Required(ErrorMessage = "Country name is required.")]
-    [MaxLength(50, ErrorMessage = "Country name must be 50 characters or fewer.")]
     public string Name { get; set; } = string.Empty;
 }

--- a/Sakila.Contracts/Languages/Commands/LanguageCreateRequest.cs
+++ b/Sakila.Contracts/Languages/Commands/LanguageCreateRequest.cs
@@ -1,8 +1,11 @@
 using MediatR;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sakila.Contracts.Languages.Commands;
 
 public class LanguageCreateRequest : IRequest<int>
 {
+    [Required(ErrorMessage = "Language name is required.")]
+    [MaxLength(20, ErrorMessage = "Language name must be 20 characters or fewer.")]
     public string Name { get; init; } = string.Empty;
 }

--- a/Sakila.Contracts/Languages/Commands/LanguageUpdateRequest.cs
+++ b/Sakila.Contracts/Languages/Commands/LanguageUpdateRequest.cs
@@ -1,9 +1,12 @@
 using MediatR;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sakila.Contracts.Languages.Commands;
 
 public class LanguageUpdateRequest : IRequest<Unit>
 {
     public int Id { get; init; }
+    [Required(ErrorMessage = "Language name is required.")]
+    [MaxLength(20, ErrorMessage = "Language name must be 20 characters or fewer.")]
     public string Name { get; init; } = string.Empty;
 }

--- a/Sakila.Contracts/Languages/Queries/Responses/LanguageGetByIdResponse.cs
+++ b/Sakila.Contracts/Languages/Queries/Responses/LanguageGetByIdResponse.cs
@@ -1,12 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace Sakila.Contracts.Languages.Queries.Responses;
 
 public class LanguageGetByIdResponse
 {
     public int Id { get; init; }
 
-    [Required(ErrorMessage = "Language name is required.")]
-    [MaxLength(20, ErrorMessage = "Language name must be 20 characters or fewer.")]
     public string Name { get; set; } = string.Empty;
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -1,0 +1,26 @@
+@using Sakila.Web.Pages.Components
+@if (Visible)
+{
+    <div class="modal show d-block" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Add Country</h5>
+                    </div>
+                    <div class="modal-body">
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name" />
+                        <ValidationMessage For="@(() => Country.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Add</button>
+                    </div>
+                </EditForm>
+            </div>
+        </div>
+    </div>
+}
+

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Components;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Web.Abstractions;
+
+namespace Sakila.Web.Pages.Countries.Components;
+
+public partial class CountryCreateDialog
+{
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public CountryCreateRequest Country { get; set; } = new();
+    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnSubmit { get; set; }
+}
+

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -1,0 +1,26 @@
+@using Sakila.Web.Pages.Components
+@if (Visible)
+{
+    <div class="modal show d-block" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Edit Country</h5>
+                    </div>
+                    <div class="modal-body">
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name" />
+                        <ValidationMessage For="@(() => Country.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Edit</button>
+                    </div>
+                </EditForm>
+            </div>
+        </div>
+    </div>
+}
+

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Components;
+using Sakila.Contracts.Countries.Commands;
+using Sakila.Web.Abstractions;
+
+namespace Sakila.Web.Pages.Countries.Components;
+
+public partial class CountryUpdateDialog
+{
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public CountryUpdateRequest Country { get; set; } = new();
+    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback OnSubmit { get; set; }
+}
+

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -3,7 +3,7 @@
 
 <h3>Countries</h3>
 
-<button class="btn btn-primary mb-3" @onclick="() => ShowDialog()">Add Country</button>
+<button class="btn btn-primary mb-3" @onclick="ShowCreateDialog">Add Country</button>
 
 @if (_getAllResponse?.Data?.Countries == null)
 {
@@ -26,7 +26,7 @@ else
             <tr>
                 <td>@country.Name</td>
                 <td>
-                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowDialog(country)">Edit</button>
+                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowUpdateDialog(country)">Edit</button>
                     <button class="btn btn-sm btn-danger" @onclick="() => ShowDeleteDialog(country)">Delete</button>
                 </td>
             </tr>
@@ -35,11 +35,17 @@ else
     </table>
 }
 
-<CountryFormDialog Visible="_isDialogOpen"
-                   Country="_selectedCountry"
-                   ApiResponse="_otherResponse"
-                   OnCancel="CloseDialog"
-                   OnSubmit="SubmitCountry"/>
+<CountryCreateDialog Visible="_isCreateDialogOpen"
+                     Country="_createCountry"
+                     ApiResponse="_otherResponse"
+                     OnCancel="CloseCreateDialog"
+                     OnSubmit="() => SubmitCreateRequest(_createCountry)"/>
+
+<CountryUpdateDialog Visible="_isUpdateDialogOpen"
+                     Country="_updateCountry"
+                     ApiResponse="_otherResponse"
+                     OnCancel="CloseUpdateDialog"
+                     OnSubmit="() => SubmitUpdateRequest(_updateCountry)"/>
 
 <ConfirmDelete Visible="_isDeleteDialogOpen"
                Country="_selectedCountry"

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -9,9 +9,12 @@ public partial class List
 {
     private IApiResponse<CountryGetAllResponse>? _getAllResponse;
     private bool _isDeleteDialogOpen;
-    private bool _isDialogOpen;
+    private bool _isCreateDialogOpen;
+    private bool _isUpdateDialogOpen;
     private IApiResponse<object>? _otherResponse;
     private CountryGetByIdResponse _selectedCountry = new();
+    private CountryCreateRequest _createCountry = new();
+    private CountryUpdateRequest _updateCountry = new();
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -19,46 +22,55 @@ public partial class List
         await RefreshCountries();
     }
 
-    private void ShowDialog(CountryGetByIdResponse? country = null)
+    private void ShowCreateDialog()
     {
-        if (country is null)
-            _selectedCountry = new CountryGetByIdResponse();
-        else
-            _selectedCountry = new CountryGetByIdResponse
-            {
-                Id = country.Id,
-                Name = country.Name
-            };
-
+        _createCountry = new CountryCreateRequest();
         _otherResponse = null;
-        _isDialogOpen = true;
+        _isCreateDialogOpen = true;
     }
 
-    private void CloseDialog()
+    private void ShowUpdateDialog(CountryGetByIdResponse country)
     {
-        _isDialogOpen = false;
-        _selectedCountry = new CountryGetByIdResponse();
+        _updateCountry = new CountryUpdateRequest
+        {
+            Id = country.Id,
+            Name = country.Name
+        };
+        _otherResponse = null;
+        _isUpdateDialogOpen = true;
+    }
+
+    private void CloseCreateDialog()
+    {
+        _isCreateDialogOpen = false;
+        _createCountry = new CountryCreateRequest();
         _otherResponse = null;
     }
 
-    private async Task SubmitCountry()
+    private void CloseUpdateDialog()
     {
+        _isUpdateDialogOpen = false;
+        _updateCountry = new CountryUpdateRequest();
         _otherResponse = null;
-        if (_selectedCountry.Id == 0)
-        {
-            var request = new CountryCreateRequest { Name = _selectedCountry.Name };
-            _otherResponse = await CountryService.CreateAsync(request);
-        }
-        else
-        {
-            var request = new CountryUpdateRequest { Id = _selectedCountry.Id, Name = _selectedCountry.Name };
-            _otherResponse = await CountryService.UpdateAsync(request);
-        }
+    }
 
+    private async Task SubmitCreateRequest(CountryCreateRequest request)
+    {
+        _otherResponse = await CountryService.CreateAsync(request);
         if (_otherResponse.IsSuccess)
         {
             await RefreshCountries();
-            CloseDialog();
+            CloseCreateDialog();
+        }
+    }
+
+    private async Task SubmitUpdateRequest(CountryUpdateRequest request)
+    {
+        _otherResponse = await CountryService.UpdateAsync(request);
+        if (_otherResponse.IsSuccess)
+        {
+            await RefreshCountries();
+            CloseUpdateDialog();
         }
     }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -6,20 +6,21 @@
             <div class="modal-content">
                 <EditForm Model="Language" OnValidSubmit="OnSubmit">
                     <div class="modal-header">
-                        <h5 class="modal-title">@Title Language</h5>
+                        <h5 class="modal-title">Add Language</h5>
                     </div>
                     <div class="modal-body">
-                        <DataAnnotationsValidator/>
-                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name"/>
-                        <ValidationMessage For="@(() => Language.Name)"/>
-                        <GeneralErrors Messages="ApiResponse?.GeneralErrors"/>
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name" />
+                        <ValidationMessage For="@(() => Language.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">@Title</button>
+                        <button type="submit" class="btn btn-primary">Add</button>
                     </div>
                 </EditForm>
             </div>
         </div>
     </div>
 }
+

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -1,15 +1,15 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Languages.Queries.Responses;
+using Sakila.Contracts.Languages.Commands;
 using Sakila.Web.Abstractions;
 
 namespace Sakila.Web.Pages.Languages.Components;
 
-public partial class LanguageFormDialog
+public partial class LanguageCreateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
+    [Parameter] public LanguageCreateRequest Language { get; set; } = new();
     [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnSubmit { get; set; }
-    private string Title => Language.Id != 0 ? "Edit" : "Add";
 }
+

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -4,22 +4,23 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                <EditForm Model="Language" OnValidSubmit="OnSubmit">
                     <div class="modal-header">
-                        <h5 class="modal-title">@Title Country</h5>
+                        <h5 class="modal-title">Edit Language</h5>
                     </div>
                     <div class="modal-body">
-                        <DataAnnotationsValidator/>
-                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name"/>
-                        <ValidationMessage For="@(() => Country.Name)"/>
-                        <GeneralErrors Messages="ApiResponse?.GeneralErrors"/>
+                        <DataAnnotationsValidator />
+                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name" />
+                        <ValidationMessage For="@(() => Language.Name)" />
+                        <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">@Title</button>
+                        <button type="submit" class="btn btn-primary">Edit</button>
                     </div>
                 </EditForm>
             </div>
         </div>
     </div>
 }
+

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -1,15 +1,15 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Countries.Queries.Responses;
+using Sakila.Contracts.Languages.Commands;
 using Sakila.Web.Abstractions;
 
-namespace Sakila.Web.Pages.Countries.Components;
+namespace Sakila.Web.Pages.Languages.Components;
 
-public partial class CountryFormDialog
+public partial class LanguageUpdateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
+    [Parameter] public LanguageUpdateRequest Language { get; set; } = new();
     [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
     [Parameter] public EventCallback OnSubmit { get; set; }
-    private string Title => Country.Id != 0 ? "Edit" : "Add";
 }
+

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -3,7 +3,7 @@
 
 <h3>Languages</h3>
 
-<button class="btn btn-primary mb-3" @onclick="() => ShowDialog()">Add Language</button>
+<button class="btn btn-primary mb-3" @onclick="ShowCreateDialog">Add Language</button>
 
 @if (_getAllResponse?.Data?.Languages == null)
 {
@@ -26,7 +26,7 @@ else
             <tr>
                 <td>@language.Name</td>
                 <td>
-                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowDialog(language)">Edit</button>
+                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowUpdateDialog(language)">Edit</button>
                     <button class="btn btn-sm btn-danger" @onclick="() => ShowDeleteDialog(language)">Delete</button>
                 </td>
             </tr>
@@ -35,11 +35,17 @@ else
     </table>
 }
 
-<LanguageFormDialog Visible="_isDialogOpen"
-                    Language="_selectedLanguage"
-                    ApiResponse="_otherResponse"
-                    OnCancel="CloseDialog"
-                    OnSubmit="SubmitLanguage"/>
+<LanguageCreateDialog Visible="_isCreateDialogOpen"
+                      Language="_createLanguage"
+                      ApiResponse="_otherResponse"
+                      OnCancel="CloseCreateDialog"
+                      OnSubmit="() => SubmitCreateRequest(_createLanguage)"/>
+
+<LanguageUpdateDialog Visible="_isUpdateDialogOpen"
+                      Language="_updateLanguage"
+                      ApiResponse="_otherResponse"
+                      OnCancel="CloseUpdateDialog"
+                      OnSubmit="() => SubmitUpdateRequest(_updateLanguage)"/>
 
 <ConfirmDelete Visible="_isDeleteDialogOpen"
                Language="_selectedLanguage"

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -9,9 +9,12 @@ public partial class List
 {
     private IApiResponse<LanguageGetAllResponse>? _getAllResponse;
     private bool _isDeleteDialogOpen;
-    private bool _isDialogOpen;
+    private bool _isCreateDialogOpen;
+    private bool _isUpdateDialogOpen;
     private IApiResponse<object>? _otherResponse;
     private LanguageGetByIdResponse _selectedLanguage = new();
+    private LanguageCreateRequest _createLanguage = new();
+    private LanguageUpdateRequest _updateLanguage = new();
     [Inject] public ILanguageService LanguageService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -19,46 +22,55 @@ public partial class List
         await RefreshLanguages();
     }
 
-    private void ShowDialog(LanguageGetByIdResponse? language = null)
+    private void ShowCreateDialog()
     {
-        if (language is null)
-            _selectedLanguage = new LanguageGetByIdResponse();
-        else
-            _selectedLanguage = new LanguageGetByIdResponse
-            {
-                Id = language.Id,
-                Name = language.Name
-            };
-
+        _createLanguage = new LanguageCreateRequest();
         _otherResponse = null;
-        _isDialogOpen = true;
+        _isCreateDialogOpen = true;
     }
 
-    private void CloseDialog()
+    private void ShowUpdateDialog(LanguageGetByIdResponse language)
     {
-        _isDialogOpen = false;
-        _selectedLanguage = new LanguageGetByIdResponse();
+        _updateLanguage = new LanguageUpdateRequest
+        {
+            Id = language.Id,
+            Name = language.Name
+        };
+        _otherResponse = null;
+        _isUpdateDialogOpen = true;
+    }
+
+    private void CloseCreateDialog()
+    {
+        _isCreateDialogOpen = false;
+        _createLanguage = new LanguageCreateRequest();
         _otherResponse = null;
     }
 
-    private async Task SubmitLanguage()
+    private void CloseUpdateDialog()
     {
+        _isUpdateDialogOpen = false;
+        _updateLanguage = new LanguageUpdateRequest();
         _otherResponse = null;
-        if (_selectedLanguage.Id == 0)
-        {
-            var request = new LanguageCreateRequest { Name = _selectedLanguage.Name };
-            _otherResponse = await LanguageService.CreateAsync(request);
-        }
-        else
-        {
-            var request = new LanguageUpdateRequest { Id = _selectedLanguage.Id, Name = _selectedLanguage.Name };
-            _otherResponse = await LanguageService.UpdateAsync(request);
-        }
+    }
 
+    private async Task SubmitCreateRequest(LanguageCreateRequest request)
+    {
+        _otherResponse = await LanguageService.CreateAsync(request);
         if (_otherResponse.IsSuccess)
         {
             await RefreshLanguages();
-            CloseDialog();
+            CloseCreateDialog();
+        }
+    }
+
+    private async Task SubmitUpdateRequest(LanguageUpdateRequest request)
+    {
+        _otherResponse = await LanguageService.UpdateAsync(request);
+        if (_otherResponse.IsSuccess)
+        {
+            await RefreshLanguages();
+            CloseUpdateDialog();
         }
     }
 


### PR DESCRIPTION
## Summary
- split form dialogs into create and update dialogs for languages and countries
- embed validation attributes in request contracts
- refactor list pages for the new dialogs
- rename submit helper methods for clarity

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a626f924832ea6bf85a1cc1967be