### PR TITLE
Move CRUD actions into dialogs with lazy rendering

### DIFF
--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -13,7 +13,7 @@
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-secondary" @onclick="OnCancel">No</button>
-                    <button class="btn btn-danger" @onclick="OnConfirm">Yes</button>
+                    <button class="btn btn-danger" @onclick="ConfirmAsync">Yes</button>
                 </div>
             </div>
         </div>

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -8,7 +8,18 @@ public partial class ConfirmDelete
 {
     [Parameter] public bool Visible { get; set; }
     [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnConfirm { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ICountryService CountryService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+
+    private async Task ConfirmAsync()
+    {
+        ApiResponse = await CountryService.DeleteAsync(Country.Id);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                <EditForm Model="Country" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Country</h5>
                     </div>

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -7,9 +7,20 @@ namespace Sakila.Web.Pages.Countries.Components;
 public partial class CountryCreateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public CountryCreateRequest Country { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnSubmit { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ICountryService CountryService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+    private CountryCreateRequest Country { get; set; } = new();
+
+    private async Task SubmitAsync()
+    {
+        ApiResponse = await CountryService.CreateAsync(Country);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }
 

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -4,14 +4,14 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Country" OnValidSubmit="OnSubmit">
+                <EditForm Model="Model" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Country</h5>
                     </div>
                     <div class="modal-body">
                         <DataAnnotationsValidator />
-                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name" />
-                        <ValidationMessage For="@(() => Country.Name)" />
+                        <InputText class="form-control" @bind-Value="Model.Name" placeholder="Country Name" />
+                        <ValidationMessage For="@(() => Model.Name)" />
                         <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     </div>
                     <div class="modal-footer">

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -7,9 +7,26 @@ namespace Sakila.Web.Pages.Countries.Components;
 public partial class CountryUpdateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public CountryUpdateRequest Country { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
+    [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnSubmit { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ICountryService CountryService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+    private CountryUpdateRequest Model { get; set; } = new();
+
+    protected override void OnParametersSet()
+    {
+        Model = new CountryUpdateRequest { Id = Country.Id, Name = Country.Name };
+    }
+
+    private async Task SubmitAsync()
+    {
+        ApiResponse = await CountryService.UpdateAsync(Model);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }
 

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -35,20 +35,25 @@ else
     </table>
 }
 
-<CountryCreateDialog Visible="_isCreateDialogOpen"
-                     Country="_createCountry"
-                     ApiResponse="_otherResponse"
-                     OnCancel="CloseCreateDialog"
-                     OnSubmit="() => SubmitCreateRequest(_createCountry)"/>
+@if (_isCreateDialogOpen)
+{
+    <CountryCreateDialog Visible="true"
+                         OnCancel="CloseCreateDialog"
+                         OnSuccess="OnCreateSuccess"/>
+}
 
-<CountryUpdateDialog Visible="_isUpdateDialogOpen"
-                     Country="_updateCountry"
-                     ApiResponse="_otherResponse"
-                     OnCancel="CloseUpdateDialog"
-                     OnSubmit="() => SubmitUpdateRequest(_updateCountry)"/>
+@if (_isUpdateDialogOpen)
+{
+    <CountryUpdateDialog Visible="true"
+                         Country="_selectedCountry"
+                         OnCancel="CloseUpdateDialog"
+                         OnSuccess="OnUpdateSuccess"/>
+}
 
-<ConfirmDelete Visible="_isDeleteDialogOpen"
-               Country="_selectedCountry"
-               ApiResponse="_otherResponse"
-               OnCancel="CloseDeleteDialog"
-               OnConfirm="ConfirmDelete"/>
+@if (_isDeleteDialogOpen)
+{
+    <ConfirmDelete Visible="true"
+                  Country="_selectedCountry"
+                  OnCancel="CloseDeleteDialog"
+                  OnSuccess="OnDeleteSuccess"/>
+}

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
 
@@ -11,10 +10,7 @@ public partial class List
     private bool _isDeleteDialogOpen;
     private bool _isCreateDialogOpen;
     private bool _isUpdateDialogOpen;
-    private IApiResponse<object>? _otherResponse;
     private CountryGetByIdResponse _selectedCountry = new();
-    private CountryCreateRequest _createCountry = new();
-    private CountryUpdateRequest _updateCountry = new();
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -24,54 +20,35 @@ public partial class List
 
     private void ShowCreateDialog()
     {
-        _createCountry = new CountryCreateRequest();
-        _otherResponse = null;
         _isCreateDialogOpen = true;
     }
 
     private void ShowUpdateDialog(CountryGetByIdResponse country)
     {
-        _updateCountry = new CountryUpdateRequest
-        {
-            Id = country.Id,
-            Name = country.Name
-        };
-        _otherResponse = null;
+        _selectedCountry = country;
         _isUpdateDialogOpen = true;
     }
 
     private void CloseCreateDialog()
     {
         _isCreateDialogOpen = false;
-        _createCountry = new CountryCreateRequest();
-        _otherResponse = null;
     }
 
     private void CloseUpdateDialog()
     {
         _isUpdateDialogOpen = false;
-        _updateCountry = new CountryUpdateRequest();
-        _otherResponse = null;
     }
 
-    private async Task SubmitCreateRequest(CountryCreateRequest request)
+    private async Task OnCreateSuccess()
     {
-        _otherResponse = await CountryService.CreateAsync(request);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshCountries();
-            CloseCreateDialog();
-        }
+        await RefreshCountries();
+        CloseCreateDialog();
     }
 
-    private async Task SubmitUpdateRequest(CountryUpdateRequest request)
+    private async Task OnUpdateSuccess()
     {
-        _otherResponse = await CountryService.UpdateAsync(request);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshCountries();
-            CloseUpdateDialog();
-        }
+        await RefreshCountries();
+        CloseUpdateDialog();
     }
 
     private async Task RefreshCountries()
@@ -83,22 +60,16 @@ public partial class List
     {
         _selectedCountry = country;
         _isDeleteDialogOpen = true;
-        _otherResponse = null;
     }
 
     private void CloseDeleteDialog()
     {
         _isDeleteDialogOpen = false;
-        _otherResponse = null;
     }
 
-    private async Task ConfirmDelete()
+    private async Task OnDeleteSuccess()
     {
-        _otherResponse = await CountryService.DeleteAsync(_selectedCountry.Id);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshCountries();
-            CloseDeleteDialog();
-        }
+        await RefreshCountries();
+        CloseDeleteDialog();
     }
 }

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -13,7 +13,7 @@
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-secondary" @onclick="OnCancel">No</button>
-                    <button class="btn btn-danger" @onclick="OnConfirm">Yes</button>
+                    <button class="btn btn-danger" @onclick="ConfirmAsync">Yes</button>
                 </div>
             </div>
         </div>

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -8,7 +8,18 @@ public partial class ConfirmDelete
 {
     [Parameter] public bool Visible { get; set; }
     [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnConfirm { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ILanguageService LanguageService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+
+    private async Task ConfirmAsync()
+    {
+        ApiResponse = await LanguageService.DeleteAsync(Language.Id);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Language" OnValidSubmit="OnSubmit">
+                <EditForm Model="Language" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Language</h5>
                     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -7,9 +7,20 @@ namespace Sakila.Web.Pages.Languages.Components;
 public partial class LanguageCreateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public LanguageCreateRequest Language { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnSubmit { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ILanguageService LanguageService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+    private LanguageCreateRequest Language { get; set; } = new();
+
+    private async Task SubmitAsync()
+    {
+        ApiResponse = await LanguageService.CreateAsync(Language);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -4,14 +4,14 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Language" OnValidSubmit="OnSubmit">
+                <EditForm Model="Model" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Language</h5>
                     </div>
                     <div class="modal-body">
                         <DataAnnotationsValidator />
-                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name" />
-                        <ValidationMessage For="@(() => Language.Name)" />
+                        <InputText class="form-control" @bind-Value="Model.Name" placeholder="Language Name" />
+                        <ValidationMessage For="@(() => Model.Name)" />
                         <GeneralErrors Messages="ApiResponse?.GeneralErrors" />
                     </div>
                     <div class="modal-footer">

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -7,9 +7,26 @@ namespace Sakila.Web.Pages.Languages.Components;
 public partial class LanguageUpdateDialog
 {
     [Parameter] public bool Visible { get; set; }
-    [Parameter] public LanguageUpdateRequest Language { get; set; } = new();
-    [Parameter] public IApiResponse<object>? ApiResponse { get; set; }
+    [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
     [Parameter] public EventCallback OnCancel { get; set; }
-    [Parameter] public EventCallback OnSubmit { get; set; }
+    [Parameter] public EventCallback OnSuccess { get; set; }
+    [Inject] public ILanguageService LanguageService { get; set; } = null!;
+
+    public IApiResponse<object>? ApiResponse { get; set; }
+    private LanguageUpdateRequest Model { get; set; } = new();
+
+    protected override void OnParametersSet()
+    {
+        Model = new LanguageUpdateRequest { Id = Language.Id, Name = Language.Name };
+    }
+
+    private async Task SubmitAsync()
+    {
+        ApiResponse = await LanguageService.UpdateAsync(Model);
+        if (ApiResponse.IsSuccess)
+        {
+            await OnSuccess.InvokeAsync();
+        }
+    }
 }
 

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -35,20 +35,25 @@ else
     </table>
 }
 
-<LanguageCreateDialog Visible="_isCreateDialogOpen"
-                      Language="_createLanguage"
-                      ApiResponse="_otherResponse"
-                      OnCancel="CloseCreateDialog"
-                      OnSubmit="() => SubmitCreateRequest(_createLanguage)"/>
+@if (_isCreateDialogOpen)
+{
+    <LanguageCreateDialog Visible="true"
+                          OnCancel="CloseCreateDialog"
+                          OnSuccess="OnCreateSuccess"/>
+}
 
-<LanguageUpdateDialog Visible="_isUpdateDialogOpen"
-                      Language="_updateLanguage"
-                      ApiResponse="_otherResponse"
-                      OnCancel="CloseUpdateDialog"
-                      OnSubmit="() => SubmitUpdateRequest(_updateLanguage)"/>
+@if (_isUpdateDialogOpen)
+{
+    <LanguageUpdateDialog Visible="true"
+                          Language="_selectedLanguage"
+                          OnCancel="CloseUpdateDialog"
+                          OnSuccess="OnUpdateSuccess"/>
+}
 
-<ConfirmDelete Visible="_isDeleteDialogOpen"
-               Language="_selectedLanguage"
-               ApiResponse="_otherResponse"
-               OnCancel="CloseDeleteDialog"
-               OnConfirm="ConfirmDelete"/>
+@if (_isDeleteDialogOpen)
+{
+    <ConfirmDelete Visible="true"
+                  Language="_selectedLanguage"
+                  OnCancel="CloseDeleteDialog"
+                  OnSuccess="OnDeleteSuccess"/>
+}

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
 
@@ -11,10 +10,7 @@ public partial class List
     private bool _isDeleteDialogOpen;
     private bool _isCreateDialogOpen;
     private bool _isUpdateDialogOpen;
-    private IApiResponse<object>? _otherResponse;
     private LanguageGetByIdResponse _selectedLanguage = new();
-    private LanguageCreateRequest _createLanguage = new();
-    private LanguageUpdateRequest _updateLanguage = new();
     [Inject] public ILanguageService LanguageService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -24,54 +20,35 @@ public partial class List
 
     private void ShowCreateDialog()
     {
-        _createLanguage = new LanguageCreateRequest();
-        _otherResponse = null;
         _isCreateDialogOpen = true;
     }
 
     private void ShowUpdateDialog(LanguageGetByIdResponse language)
     {
-        _updateLanguage = new LanguageUpdateRequest
-        {
-            Id = language.Id,
-            Name = language.Name
-        };
-        _otherResponse = null;
+        _selectedLanguage = language;
         _isUpdateDialogOpen = true;
     }
 
     private void CloseCreateDialog()
     {
         _isCreateDialogOpen = false;
-        _createLanguage = new LanguageCreateRequest();
-        _otherResponse = null;
     }
 
     private void CloseUpdateDialog()
     {
         _isUpdateDialogOpen = false;
-        _updateLanguage = new LanguageUpdateRequest();
-        _otherResponse = null;
     }
 
-    private async Task SubmitCreateRequest(LanguageCreateRequest request)
+    private async Task OnCreateSuccess()
     {
-        _otherResponse = await LanguageService.CreateAsync(request);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshLanguages();
-            CloseCreateDialog();
-        }
+        await RefreshLanguages();
+        CloseCreateDialog();
     }
 
-    private async Task SubmitUpdateRequest(LanguageUpdateRequest request)
+    private async Task OnUpdateSuccess()
     {
-        _otherResponse = await LanguageService.UpdateAsync(request);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshLanguages();
-            CloseUpdateDialog();
-        }
+        await RefreshLanguages();
+        CloseUpdateDialog();
     }
 
     private async Task RefreshLanguages()
@@ -83,22 +60,16 @@ public partial class List
     {
         _selectedLanguage = language;
         _isDeleteDialogOpen = true;
-        _otherResponse = null;
     }
 
     private void CloseDeleteDialog()
     {
         _isDeleteDialogOpen = false;
-        _otherResponse = null;
     }
 
-    private async Task ConfirmDelete()
+    private async Task OnDeleteSuccess()
     {
-        _otherResponse = await LanguageService.DeleteAsync(_selectedLanguage.Id);
-        if (_otherResponse.IsSuccess)
-        {
-            await RefreshLanguages();
-            CloseDeleteDialog();
-        }
+        await RefreshLanguages();
+        CloseDeleteDialog();
     }
 }


### PR DESCRIPTION
## Summary
- handle create/update/delete logic inside the dialogs
- only instantiate dialogs when opened to lazy-load them
- move dialog state into the dialog components themselves

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ac54c778832e820ec01c6ff34831