### PR TITLE
Fix route for CreatedAtAction

### DIFF
--- a/Sakila.API/Controllers/CountriesController.cs
+++ b/Sakila.API/Controllers/CountriesController.cs
@@ -17,7 +17,7 @@ public class CountriesController(IMediator mediator) : ControllerBase
         return Ok(countries);
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{id}", Name = "GetCountryById")]
     public async Task<ActionResult<CountryGetByIdResponse>> GetByIdAsync(int id)
     {
         var country = await mediator.Send(new CountryGetByIdRequest { Id = id });
@@ -37,7 +37,7 @@ public class CountriesController(IMediator mediator) : ControllerBase
     public async Task<IActionResult> PostCountryAsync(CountryCreateRequest command)
     {
         var id = await mediator.Send(command);
-        return CreatedAtAction(nameof(GetByIdAsync), new { id }, command);
+        return CreatedAtRoute("GetCountryById", new { id }, command);
     }
 
     [HttpDelete("{id}")]

--- a/Sakila.API/Controllers/LanguagesController.cs
+++ b/Sakila.API/Controllers/LanguagesController.cs
@@ -17,7 +17,7 @@ public class LanguagesController(IMediator mediator) : ControllerBase
         return Ok(languages);
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{id}", Name = "GetLanguageById")]
     public async Task<ActionResult<LanguageGetByIdResponse>> GetByIdAsync(int id)
     {
         var language = await mediator.Send(new LanguageGetByIdRequest { Id = id });
@@ -37,7 +37,7 @@ public class LanguagesController(IMediator mediator) : ControllerBase
     public async Task<IActionResult> PostLanguageAsync(LanguageCreateRequest command)
     {
         var id = await mediator.Send(command);
-        return CreatedAtAction(nameof(GetByIdAsync), new { id }, command);
+        return CreatedAtRoute("GetLanguageById", new { id }, command);
     }
 
 


### PR DESCRIPTION
## Summary
- add explicit route names for retrieving countries and languages
- use CreatedAtRoute instead of CreatedAtAction so POST endpoints return 201 without errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c9198210832eaa8c8d9d8b162f1b