### PR TITLE
Fix validation error handling for languages

### DIFF
--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Language" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Language</h5>
                     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Web.Abstractions;
 
@@ -13,13 +14,32 @@ public partial class LanguageCreateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private LanguageCreateRequest Language { get; set; } = new();
+    private EditContext _editContext = null!;
+    private ValidationMessageStore _messageStore = null!;
+
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(Language);
+        _messageStore = new ValidationMessageStore(_editContext);
+    }
 
     private async Task SubmitAsync()
     {
         ApiResponse = await LanguageService.CreateAsync(Language);
+
+        _messageStore.Clear();
+
         if (ApiResponse.IsSuccess)
         {
             await OnSuccess.InvokeAsync();
+        }
+        else
+        {
+            foreach (var (field, messages) in ApiResponse.Errors)
+            {
+                _messageStore.Add(_editContext.Field(field), messages);
+            }
+            _editContext.NotifyValidationStateChanged();
         }
     }
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Model" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Language</h5>
                     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
@@ -15,18 +16,33 @@ public partial class LanguageUpdateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private LanguageUpdateRequest Model { get; set; } = new();
+    private EditContext _editContext = null!;
+    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnParametersSet()
     {
         Model = new LanguageUpdateRequest { Id = Language.Id, Name = Language.Name };
+        _editContext = new EditContext(Model);
+        _messageStore = new ValidationMessageStore(_editContext);
     }
 
     private async Task SubmitAsync()
     {
         ApiResponse = await LanguageService.UpdateAsync(Model);
+
+        _messageStore.Clear();
+
         if (ApiResponse.IsSuccess)
         {
             await OnSuccess.InvokeAsync();
+        }
+        else
+        {
+            foreach (var (field, messages) in ApiResponse.Errors)
+            {
+                _messageStore.Add(_editContext.Field(field), messages);
+            }
+            _editContext.NotifyValidationStateChanged();
         }
     }
 }


### PR DESCRIPTION
## Summary
- wire up EditForm to an `EditContext` for language dialogs
- surface API validation errors using `ValidationMessageStore`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca664728832eaf04c40c7063aaf9