### PR TITLE
Refactor validation handling

### DIFF
--- a/Sakila.Web/Extensions/EditContextExtensions.cs
+++ b/Sakila.Web/Extensions/EditContextExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components.Forms;
+using Sakila.Web.Abstractions;
+
+namespace Sakila.Web.Extensions;
+
+public static class EditContextExtensions
+{
+    public static bool ApplyErrors(this EditContext editContext, ValidationMessageStore messageStore, IApiResponse<object>? response)
+    {
+        if (response == null)
+            return true;
+
+        messageStore.Clear();
+
+        if (response.IsSuccess)
+            return true;
+
+        foreach (var (field, messages) in response.Errors)
+        {
+            messageStore.Add(editContext.Field(field), messages);
+        }
+
+        editContext.NotifyValidationStateChanged();
+        return false;
+    }
+}
+

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Country" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Country</h5>
                     </div>

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Web.Abstractions;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Countries.Components;
 
@@ -13,14 +15,21 @@ public partial class CountryCreateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private CountryCreateRequest Country { get; set; } = new();
+    private EditContext _editContext = null!;
+    private ValidationMessageStore _messageStore = null!;
+
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(Country);
+        _messageStore = new ValidationMessageStore(_editContext);
+    }
 
     private async Task SubmitAsync()
     {
         ApiResponse = await CountryService.CreateAsync(Country);
-        if (ApiResponse.IsSuccess)
-        {
+
+        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
             await OnSuccess.InvokeAsync();
-        }
     }
 }
 

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm Model="Model" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Country</h5>
                     </div>

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Countries.Components;
 
@@ -15,19 +17,22 @@ public partial class CountryUpdateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private CountryUpdateRequest Model { get; set; } = new();
+    private EditContext _editContext = null!;
+    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnParametersSet()
     {
         Model = new CountryUpdateRequest { Id = Country.Id, Name = Country.Name };
+        _editContext = new EditContext(Model);
+        _messageStore = new ValidationMessageStore(_editContext);
     }
 
     private async Task SubmitAsync()
     {
         ApiResponse = await CountryService.UpdateAsync(Model);
-        if (ApiResponse.IsSuccess)
-        {
+
+        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
             await OnSuccess.InvokeAsync();
-        }
     }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Web.Abstractions;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Languages.Components;
 
@@ -27,20 +28,8 @@ public partial class LanguageCreateDialog
     {
         ApiResponse = await LanguageService.CreateAsync(Language);
 
-        _messageStore.Clear();
-
-        if (ApiResponse.IsSuccess)
-        {
+        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
             await OnSuccess.InvokeAsync();
-        }
-        else
-        {
-            foreach (var (field, messages) in ApiResponse.Errors)
-            {
-                _messageStore.Add(_editContext.Field(field), messages);
-            }
-            _editContext.NotifyValidationStateChanged();
-        }
     }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Languages.Components;
 
@@ -30,20 +31,8 @@ public partial class LanguageUpdateDialog
     {
         ApiResponse = await LanguageService.UpdateAsync(Model);
 
-        _messageStore.Clear();
-
-        if (ApiResponse.IsSuccess)
-        {
+        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
             await OnSuccess.InvokeAsync();
-        }
-        else
-        {
-            foreach (var (field, messages) in ApiResponse.Errors)
-            {
-                _messageStore.Add(_editContext.Field(field), messages);
-            }
-            _editContext.NotifyValidationStateChanged();
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize error mapping to EditContext
- wire country dialogs to use new helper
- simplify language dialogs

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cc1beb68832ea1ae1d3eb3a57c0c