### PR TITLE
Add callback support and integrate form context within services

### DIFF
--- a/Sakila.Web/Abstractions/IApiClient.cs
+++ b/Sakila.Web/Abstractions/IApiClient.cs
@@ -4,11 +4,21 @@ namespace Sakila.Web.Abstractions;
 
 public interface IApiClient
 {
-    Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url);
+    Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url,
+        Func<IApiResponse<TResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<TResponse>, Task>? onFailure = null);
 
-    Task<IApiResponse<object>>
-        PostAsync<TRequest>(string url, TRequest request, IValidator<TRequest>? validator = null);
+    Task<IApiResponse<object>> PostAsync<TRequest>(string url, TRequest request,
+        IValidator<TRequest>? validator = null,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null);
 
-    Task<IApiResponse<object>> PutAsync<TRequest>(string url, TRequest request, IValidator<TRequest>? validator = null);
-    Task<IApiResponse<object>> DeleteAsync(string url);
+    Task<IApiResponse<object>> PutAsync<TRequest>(string url, TRequest request,
+        IValidator<TRequest>? validator = null,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null);
+
+    Task<IApiResponse<object>> DeleteAsync(string url,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Abstractions/ICountryService.cs
+++ b/Sakila.Web/Abstractions/ICountryService.cs
@@ -1,13 +1,23 @@
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace Sakila.Web.Abstractions;
 
 public interface ICountryService
 {
+    EditContext EditContext { get; }
+    ValidationMessageStore MessageStore { get; }
+    void Initialize(object model);
     Task<IApiResponse<CountryGetAllResponse>> GetAllAsync();
     Task<IApiResponse<CountryGetByIdResponse>> GetByIdAsync(int id);
-    Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request);
-    Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request);
-    Task<IApiResponse<object>> DeleteAsync(int id);
+    Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
+    Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
+    Task<IApiResponse<object>> DeleteAsync(int id,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Abstractions/ILanguageService.cs
+++ b/Sakila.Web/Abstractions/ILanguageService.cs
@@ -1,13 +1,23 @@
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace Sakila.Web.Abstractions;
 
 public interface ILanguageService
 {
+    EditContext EditContext { get; }
+    ValidationMessageStore MessageStore { get; }
+    void Initialize(object model);
     Task<IApiResponse<LanguageGetAllResponse>> GetAllAsync();
     Task<IApiResponse<LanguageGetByIdResponse>> GetByIdAsync(int id);
-    Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request);
-    Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request);
-    Task<IApiResponse<object>> DeleteAsync(int id);
+    Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
+    Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
+    Task<IApiResponse<object>> DeleteAsync(int id,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Common/ApiClient.cs
+++ b/Sakila.Web/Common/ApiClient.cs
@@ -12,86 +12,126 @@ public class ApiClient(HttpClient httpClient) : IApiClient
 
     private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
 
-    public async Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url)
+    public async Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url,
+        Func<IApiResponse<TResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<TResponse>, Task>? onFailure = null)
     {
+        IApiResponse<TResponse> apiResponse;
         try
         {
             var response = await httpClient.GetAsync($"{Base}{url}");
-            return await HandleResponse<TResponse>(response);
+            apiResponse = await HandleResponse<TResponse>(response);
         }
         catch (ApiValidationException exception)
         {
-            return new ApiResponse<TResponse>(exception.Errors);
+            apiResponse = new ApiResponse<TResponse>(exception.Errors);
         }
         catch (HttpRequestException exception)
         {
-            return new ApiResponse<TResponse>(exception.Message);
+            apiResponse = new ApiResponse<TResponse>(exception.Message);
         }
+
+        if (apiResponse.IsSuccess)
+            if (onSuccess != null) await onSuccess(apiResponse);
+        if (!apiResponse.IsSuccess)
+            if (onFailure != null) await onFailure(apiResponse);
+
+        return apiResponse;
     }
 
     public async Task<IApiResponse<object>> PostAsync<TRequest>(string url, TRequest request,
-        IValidator<TRequest>? createValidator = null)
+        IValidator<TRequest>? createValidator = null,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null)
     {
+        IApiResponse<object> apiResponse;
         try
         {
             if (createValidator != null)
                 await createValidator.ValidateAndThrowAsync(request);
             var response = await httpClient.PostAsJsonAsync($"{Base}{url}", request);
-            return await HandleResponse<object>(response);
+            apiResponse = await HandleResponse<object>(response);
         }
         catch (ValidationException exception)
         {
-            return new ApiResponse<object>(exception);
+            apiResponse = new ApiResponse<object>(exception);
         }
         catch (ApiValidationException exception)
         {
-            return new ApiResponse<object>(exception.Errors);
+            apiResponse = new ApiResponse<object>(exception.Errors);
         }
         catch (HttpRequestException exception)
         {
-            return new ApiResponse<object>(exception.Message);
+            apiResponse = new ApiResponse<object>(exception.Message);
         }
+
+        if (apiResponse.IsSuccess)
+            if (onSuccess != null) await onSuccess(apiResponse);
+        if (!apiResponse.IsSuccess)
+            if (onFailure != null) await onFailure(apiResponse);
+
+        return apiResponse;
     }
 
     public async Task<IApiResponse<object>> PutAsync<TRequest>(string url, TRequest request,
-        IValidator<TRequest>? updateValidator = null)
+        IValidator<TRequest>? updateValidator = null,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null)
     {
+        IApiResponse<object> apiResponse;
         try
         {
             if (updateValidator != null)
                 await updateValidator.ValidateAndThrowAsync(request);
             var response = await httpClient.PutAsJsonAsync($"{Base}{url}", request);
-            return await HandleResponse<object>(response);
+            apiResponse = await HandleResponse<object>(response);
         }
         catch (ValidationException exception)
         {
-            return new ApiResponse<object>(exception);
+            apiResponse = new ApiResponse<object>(exception);
         }
         catch (ApiValidationException exception)
         {
-            return new ApiResponse<object>(exception.Errors);
+            apiResponse = new ApiResponse<object>(exception.Errors);
         }
         catch (HttpRequestException exception)
         {
-            return new ApiResponse<object>(exception.Message);
+            apiResponse = new ApiResponse<object>(exception.Message);
         }
+
+        if (apiResponse.IsSuccess)
+            if (onSuccess != null) await onSuccess(apiResponse);
+        if (!apiResponse.IsSuccess)
+            if (onFailure != null) await onFailure(apiResponse);
+
+        return apiResponse;
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(string url)
+    public async Task<IApiResponse<object>> DeleteAsync(string url,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<IApiResponse<object>, Task>? onFailure = null)
     {
+        IApiResponse<object> apiResponse;
         try
         {
             var response = await httpClient.DeleteAsync($"{Base}{url}");
-            return await HandleResponse<object>(response);
+            apiResponse = await HandleResponse<object>(response);
         }
         catch (ApiValidationException exception)
         {
-            return new ApiResponse<object>(exception.Errors);
+            apiResponse = new ApiResponse<object>(exception.Errors);
         }
         catch (HttpRequestException exception)
         {
-            return new ApiResponse<object>(exception.Message);
+            apiResponse = new ApiResponse<object>(exception.Message);
         }
+
+        if (apiResponse.IsSuccess)
+            if (onSuccess != null) await onSuccess(apiResponse);
+        if (!apiResponse.IsSuccess)
+            if (onFailure != null) await onFailure(apiResponse);
+
+        return apiResponse;
     }
 
     private static async Task<IApiResponse<TResponse>> HandleResponse<TResponse>(HttpResponseMessage response)

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -16,10 +16,7 @@ public partial class ConfirmDelete
 
     private async Task ConfirmAsync()
     {
-        ApiResponse = await CountryService.DeleteAsync(Country.Id);
-        if (ApiResponse.IsSuccess)
-        {
-            await OnSuccess.InvokeAsync();
-        }
+        ApiResponse = await CountryService.DeleteAsync(Country.Id,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Country</h5>
                     </div>

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Web.Abstractions;
-using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Countries.Components;
 
@@ -15,21 +13,16 @@ public partial class CountryCreateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private CountryCreateRequest Country { get; set; } = new();
-    private EditContext _editContext = null!;
-    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnInitialized()
     {
-        _editContext = new EditContext(Country);
-        _messageStore = new ValidationMessageStore(_editContext);
+        CountryService.Initialize(Country);
     }
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await CountryService.CreateAsync(Country);
-
-        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
-            await OnSuccess.InvokeAsync();
+        ApiResponse = await CountryService.CreateAsync(Country,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }
 

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Country</h5>
                     </div>

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -1,9 +1,7 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
-using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Countries.Components;
 
@@ -17,22 +15,17 @@ public partial class CountryUpdateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private CountryUpdateRequest Model { get; set; } = new();
-    private EditContext _editContext = null!;
-    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnParametersSet()
     {
         Model = new CountryUpdateRequest { Id = Country.Id, Name = Country.Name };
-        _editContext = new EditContext(Model);
-        _messageStore = new ValidationMessageStore(_editContext);
+        CountryService.Initialize(Model);
     }
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await CountryService.UpdateAsync(Model);
-
-        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
-            await OnSuccess.InvokeAsync();
+        ApiResponse = await CountryService.UpdateAsync(Model,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -16,10 +16,7 @@ public partial class ConfirmDelete
 
     private async Task ConfirmAsync()
     {
-        ApiResponse = await LanguageService.DeleteAsync(Language.Id);
-        if (ApiResponse.IsSuccess)
-        {
-            await OnSuccess.InvokeAsync();
-        }
+        ApiResponse = await LanguageService.DeleteAsync(Language.Id,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Add Language</h5>
                     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Web.Abstractions;
-using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Languages.Components;
 
@@ -15,21 +13,16 @@ public partial class LanguageCreateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private LanguageCreateRequest Language { get; set; } = new();
-    private EditContext _editContext = null!;
-    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnInitialized()
     {
-        _editContext = new EditContext(Language);
-        _messageStore = new ValidationMessageStore(_editContext);
+        LanguageService.Initialize(Language);
     }
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await LanguageService.CreateAsync(Language);
-
-        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
-            await OnSuccess.InvokeAsync();
+        ApiResponse = await LanguageService.CreateAsync(Language,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -4,7 +4,7 @@
     <div class="modal show d-block" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
-                <EditForm EditContext="_editContext" OnValidSubmit="SubmitAsync">
+                <EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
                     <div class="modal-header">
                         <h5 class="modal-title">Edit Language</h5>
                     </div>

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -1,9 +1,7 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
-using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Languages.Components;
 
@@ -17,22 +15,17 @@ public partial class LanguageUpdateDialog
 
     public IApiResponse<object>? ApiResponse { get; set; }
     private LanguageUpdateRequest Model { get; set; } = new();
-    private EditContext _editContext = null!;
-    private ValidationMessageStore _messageStore = null!;
 
     protected override void OnParametersSet()
     {
         Model = new LanguageUpdateRequest { Id = Language.Id, Name = Language.Name };
-        _editContext = new EditContext(Model);
-        _messageStore = new ValidationMessageStore(_editContext);
+        LanguageService.Initialize(Model);
     }
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await LanguageService.UpdateAsync(Model);
-
-        if (_editContext.ApplyErrors(_messageStore, ApiResponse))
-            await OnSuccess.InvokeAsync();
+        ApiResponse = await LanguageService.UpdateAsync(Model,
+            async _ => await OnSuccess.InvokeAsync());
     }
 }
 

--- a/Sakila.Web/Services/Implementations/CountryService.cs
+++ b/Sakila.Web/Services/Implementations/CountryService.cs
@@ -2,6 +2,8 @@ using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Microsoft.AspNetCore.Components.Forms;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Services.Implementations;
 
@@ -11,6 +13,15 @@ public class CountryService(
     IValidator<CountryUpdateRequest> updateValidator) : ICountryService
 {
     private const string Resource = "countries";
+
+    public EditContext EditContext { get; private set; } = null!;
+    public ValidationMessageStore MessageStore { get; private set; } = null!;
+
+    public void Initialize(object model)
+    {
+        EditContext = new EditContext(model);
+        MessageStore = new ValidationMessageStore(EditContext);
+    }
 
     public async Task<IApiResponse<CountryGetAllResponse>> GetAllAsync()
     {
@@ -22,18 +33,59 @@ public class CountryService(
         return await apiClient.GetAsync<CountryGetByIdResponse>($"{Resource}/{id}");
     }
 
-    public async Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request)
+    public async Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.PostAsync(Resource, request, createValidator);
+        var response = await apiClient.PostAsync(Resource, request, createValidator);
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            EditContext.ApplyErrors(MessageStore, response);
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 
-    public async Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request)
+    public async Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
+        var response = await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            EditContext.ApplyErrors(MessageStore, response);
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(int id)
+    public async Task<IApiResponse<object>> DeleteAsync(int id,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.DeleteAsync($"{Resource}/{id}");
+        var response = await apiClient.DeleteAsync($"{Resource}/{id}");
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 }

--- a/Sakila.Web/Services/Implementations/LanguageService.cs
+++ b/Sakila.Web/Services/Implementations/LanguageService.cs
@@ -2,6 +2,8 @@ using FluentValidation;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Microsoft.AspNetCore.Components.Forms;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Services.Implementations;
 
@@ -11,6 +13,15 @@ public class LanguageService(
     IValidator<LanguageUpdateRequest> updateValidator) : ILanguageService
 {
     private const string Resource = "languages";
+
+    public EditContext EditContext { get; private set; } = null!;
+    public ValidationMessageStore MessageStore { get; private set; } = null!;
+
+    public void Initialize(object model)
+    {
+        EditContext = new EditContext(model);
+        MessageStore = new ValidationMessageStore(EditContext);
+    }
 
     public async Task<IApiResponse<LanguageGetAllResponse>> GetAllAsync()
     {
@@ -22,18 +33,59 @@ public class LanguageService(
         return await apiClient.GetAsync<LanguageGetByIdResponse>($"{Resource}/{id}");
     }
 
-    public async Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request)
+    public async Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.PostAsync(Resource, request, createValidator);
+        var response = await apiClient.PostAsync(Resource, request, createValidator);
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            EditContext.ApplyErrors(MessageStore, response);
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 
-    public async Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request)
+    public async Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
+        var response = await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            EditContext.ApplyErrors(MessageStore, response);
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(int id)
+    public async Task<IApiResponse<object>> DeleteAsync(int id,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        return await apiClient.DeleteAsync($"{Resource}/{id}");
+        var response = await apiClient.DeleteAsync($"{Resource}/{id}");
+
+        if (response.IsSuccess)
+        {
+            if (onSuccess != null) await onSuccess(response);
+        }
+        else
+        {
+            if (onFailure != null) await onFailure(response.Errors);
+        }
+
+        return response;
     }
 }


### PR DESCRIPTION
## Summary
- add optional success/failure callbacks to `IApiClient`
- implement callbacks in `ApiClient`
- expose `EditContext` and `ValidationMessageStore` through `ICountryService` and `ILanguageService`
- update services to manage form context and invoke callbacks
- adapt country and language components to use service-managed contexts

## Testing
- `dotnet build CRUD-DSC.sln -warnaserror` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849cfe6e994832eafe16c0d994fcf77