### PR TITLE
Switch API client to callback pattern

### DIFF
--- a/Sakila.Web/Abstractions/IApiClient.cs
+++ b/Sakila.Web/Abstractions/IApiClient.cs
@@ -4,21 +4,21 @@ namespace Sakila.Web.Abstractions;
 
 public interface IApiClient
 {
-    Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url,
+    Task GetAsync<TResponse>(string url,
         Func<IApiResponse<TResponse>, Task>? onSuccess = null,
         Func<IApiResponse<TResponse>, Task>? onFailure = null);
 
-    Task<IApiResponse<object>> PostAsync<TRequest>(string url, TRequest request,
+    Task PostAsync<TRequest>(string url, TRequest request,
         IValidator<TRequest>? validator = null,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null);
 
-    Task<IApiResponse<object>> PutAsync<TRequest>(string url, TRequest request,
+    Task PutAsync<TRequest>(string url, TRequest request,
         IValidator<TRequest>? validator = null,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null);
 
-    Task<IApiResponse<object>> DeleteAsync(string url,
+    Task DeleteAsync(string url,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Abstractions/ICountryService.cs
+++ b/Sakila.Web/Abstractions/ICountryService.cs
@@ -9,15 +9,19 @@ public interface ICountryService
     EditContext EditContext { get; }
     ValidationMessageStore MessageStore { get; }
     void Initialize(object model);
-    Task<IApiResponse<CountryGetAllResponse>> GetAllAsync();
-    Task<IApiResponse<CountryGetByIdResponse>> GetByIdAsync(int id);
-    Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request,
+    Task GetAllAsync(
+        Func<IApiResponse<CountryGetAllResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<CountryGetAllResponse>, Task>? onFailure = null);
+    Task GetByIdAsync(int id,
+        Func<IApiResponse<CountryGetByIdResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<CountryGetByIdResponse>, Task>? onFailure = null);
+    Task CreateAsync(CountryCreateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
-    Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request,
+    Task UpdateAsync(CountryUpdateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
-    Task<IApiResponse<object>> DeleteAsync(int id,
+    Task DeleteAsync(int id,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Abstractions/ILanguageService.cs
+++ b/Sakila.Web/Abstractions/ILanguageService.cs
@@ -9,15 +9,19 @@ public interface ILanguageService
     EditContext EditContext { get; }
     ValidationMessageStore MessageStore { get; }
     void Initialize(object model);
-    Task<IApiResponse<LanguageGetAllResponse>> GetAllAsync();
-    Task<IApiResponse<LanguageGetByIdResponse>> GetByIdAsync(int id);
-    Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request,
+    Task GetAllAsync(
+        Func<IApiResponse<LanguageGetAllResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<LanguageGetAllResponse>, Task>? onFailure = null);
+    Task GetByIdAsync(int id,
+        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onFailure = null);
+    Task CreateAsync(LanguageCreateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
-    Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request,
+    Task UpdateAsync(LanguageUpdateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
-    Task<IApiResponse<object>> DeleteAsync(int id,
+    Task DeleteAsync(int id,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null);
 }

--- a/Sakila.Web/Common/ApiClient.cs
+++ b/Sakila.Web/Common/ApiClient.cs
@@ -12,7 +12,7 @@ public class ApiClient(HttpClient httpClient) : IApiClient
 
     private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
 
-    public async Task<IApiResponse<TResponse>> GetAsync<TResponse>(string url,
+    public async Task GetAsync<TResponse>(string url,
         Func<IApiResponse<TResponse>, Task>? onSuccess = null,
         Func<IApiResponse<TResponse>, Task>? onFailure = null)
     {
@@ -35,11 +35,9 @@ public class ApiClient(HttpClient httpClient) : IApiClient
             if (onSuccess != null) await onSuccess(apiResponse);
         if (!apiResponse.IsSuccess)
             if (onFailure != null) await onFailure(apiResponse);
-
-        return apiResponse;
     }
 
-    public async Task<IApiResponse<object>> PostAsync<TRequest>(string url, TRequest request,
+    public async Task PostAsync<TRequest>(string url, TRequest request,
         IValidator<TRequest>? createValidator = null,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null)
@@ -69,11 +67,9 @@ public class ApiClient(HttpClient httpClient) : IApiClient
             if (onSuccess != null) await onSuccess(apiResponse);
         if (!apiResponse.IsSuccess)
             if (onFailure != null) await onFailure(apiResponse);
-
-        return apiResponse;
     }
 
-    public async Task<IApiResponse<object>> PutAsync<TRequest>(string url, TRequest request,
+    public async Task PutAsync<TRequest>(string url, TRequest request,
         IValidator<TRequest>? updateValidator = null,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null)
@@ -103,11 +99,9 @@ public class ApiClient(HttpClient httpClient) : IApiClient
             if (onSuccess != null) await onSuccess(apiResponse);
         if (!apiResponse.IsSuccess)
             if (onFailure != null) await onFailure(apiResponse);
-
-        return apiResponse;
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(string url,
+    public async Task DeleteAsync(string url,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<IApiResponse<object>, Task>? onFailure = null)
     {
@@ -130,8 +124,6 @@ public class ApiClient(HttpClient httpClient) : IApiClient
             if (onSuccess != null) await onSuccess(apiResponse);
         if (!apiResponse.IsSuccess)
             if (onFailure != null) await onFailure(apiResponse);
-
-        return apiResponse;
     }
 
     private static async Task<IApiResponse<TResponse>> HandleResponse<TResponse>(HttpResponseMessage response)

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -16,7 +16,11 @@ public partial class ConfirmDelete
 
     private async Task ConfirmAsync()
     {
-        ApiResponse = await CountryService.DeleteAsync(Country.Id,
-            async _ => await OnSuccess.InvokeAsync());
+        await CountryService.DeleteAsync(Country.Id,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -21,8 +21,12 @@ public partial class CountryCreateDialog
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await CountryService.CreateAsync(Country,
-            async _ => await OnSuccess.InvokeAsync());
+        await CountryService.CreateAsync(Country,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }
 

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -24,8 +24,12 @@ public partial class CountryUpdateDialog
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await CountryService.UpdateAsync(Model,
-            async _ => await OnSuccess.InvokeAsync());
+        await CountryService.UpdateAsync(Model,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }
 

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -53,7 +53,8 @@ public partial class List
 
     private async Task RefreshCountries()
     {
-        _getAllResponse = await CountryService.GetAllAsync();
+        await CountryService.GetAllAsync(
+            async response => _getAllResponse = response);
     }
 
     private void ShowDeleteDialog(CountryGetByIdResponse country)

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -16,7 +16,11 @@ public partial class ConfirmDelete
 
     private async Task ConfirmAsync()
     {
-        ApiResponse = await LanguageService.DeleteAsync(Language.Id,
-            async _ => await OnSuccess.InvokeAsync());
+        await LanguageService.DeleteAsync(Language.Id,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -21,8 +21,12 @@ public partial class LanguageCreateDialog
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await LanguageService.CreateAsync(Language,
-            async _ => await OnSuccess.InvokeAsync());
+        await LanguageService.CreateAsync(Language,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -24,8 +24,12 @@ public partial class LanguageUpdateDialog
 
     private async Task SubmitAsync()
     {
-        ApiResponse = await LanguageService.UpdateAsync(Model,
-            async _ => await OnSuccess.InvokeAsync());
+        await LanguageService.UpdateAsync(Model,
+            async response =>
+            {
+                ApiResponse = response;
+                await OnSuccess.InvokeAsync();
+            });
     }
 }
 

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -53,7 +53,8 @@ public partial class List
 
     private async Task RefreshLanguages()
     {
-        _getAllResponse = await LanguageService.GetAllAsync();
+        await LanguageService.GetAllAsync(
+            async response => _getAllResponse = response);
     }
 
     private void ShowDeleteDialog(LanguageGetByIdResponse language)

--- a/Sakila.Web/Services/Implementations/CountryService.cs
+++ b/Sakila.Web/Services/Implementations/CountryService.cs
@@ -23,69 +23,55 @@ public class CountryService(
         MessageStore = new ValidationMessageStore(EditContext);
     }
 
-    public async Task<IApiResponse<CountryGetAllResponse>> GetAllAsync()
+    public async Task GetAllAsync(
+        Func<IApiResponse<CountryGetAllResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<CountryGetAllResponse>, Task>? onFailure = null)
     {
-        return await apiClient.GetAsync<CountryGetAllResponse>(Resource);
+        await apiClient.GetAsync(Resource, onSuccess, onFailure);
     }
 
-    public async Task<IApiResponse<CountryGetByIdResponse>> GetByIdAsync(int id)
+    public async Task GetByIdAsync(int id,
+        Func<IApiResponse<CountryGetByIdResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<CountryGetByIdResponse>, Task>? onFailure = null)
     {
-        return await apiClient.GetAsync<CountryGetByIdResponse>($"{Resource}/{id}");
+        await apiClient.GetAsync($"{Resource}/{id}", onSuccess, onFailure);
     }
 
-    public async Task<IApiResponse<object>> CreateAsync(CountryCreateRequest request,
+    public async Task CreateAsync(CountryCreateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.PostAsync(Resource, request, createValidator);
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            EditContext.ApplyErrors(MessageStore, response);
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.PostAsync(Resource, request, createValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 
-    public async Task<IApiResponse<object>> UpdateAsync(CountryUpdateRequest request,
+    public async Task UpdateAsync(CountryUpdateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            EditContext.ApplyErrors(MessageStore, response);
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(int id,
+    public async Task DeleteAsync(int id,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.DeleteAsync($"{Resource}/{id}");
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.DeleteAsync($"{Resource}/{id}",
+            onSuccess,
+            async response =>
+            {
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 }

--- a/Sakila.Web/Services/Implementations/LanguageService.cs
+++ b/Sakila.Web/Services/Implementations/LanguageService.cs
@@ -23,69 +23,55 @@ public class LanguageService(
         MessageStore = new ValidationMessageStore(EditContext);
     }
 
-    public async Task<IApiResponse<LanguageGetAllResponse>> GetAllAsync()
+    public async Task GetAllAsync(
+        Func<IApiResponse<LanguageGetAllResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<LanguageGetAllResponse>, Task>? onFailure = null)
     {
-        return await apiClient.GetAsync<LanguageGetAllResponse>(Resource);
+        await apiClient.GetAsync(Resource, onSuccess, onFailure);
     }
 
-    public async Task<IApiResponse<LanguageGetByIdResponse>> GetByIdAsync(int id)
+    public async Task GetByIdAsync(int id,
+        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onSuccess = null,
+        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onFailure = null)
     {
-        return await apiClient.GetAsync<LanguageGetByIdResponse>($"{Resource}/{id}");
+        await apiClient.GetAsync($"{Resource}/{id}", onSuccess, onFailure);
     }
 
-    public async Task<IApiResponse<object>> CreateAsync(LanguageCreateRequest request,
+    public async Task CreateAsync(LanguageCreateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.PostAsync(Resource, request, createValidator);
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            EditContext.ApplyErrors(MessageStore, response);
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.PostAsync(Resource, request, createValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 
-    public async Task<IApiResponse<object>> UpdateAsync(LanguageUpdateRequest request,
+    public async Task UpdateAsync(LanguageUpdateRequest request,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator);
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            EditContext.ApplyErrors(MessageStore, response);
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 
-    public async Task<IApiResponse<object>> DeleteAsync(int id,
+    public async Task DeleteAsync(int id,
         Func<IApiResponse<object>, Task>? onSuccess = null,
         Func<Dictionary<string, string[]>, Task>? onFailure = null)
     {
-        var response = await apiClient.DeleteAsync($"{Resource}/{id}");
-
-        if (response.IsSuccess)
-        {
-            if (onSuccess != null) await onSuccess(response);
-        }
-        else
-        {
-            if (onFailure != null) await onFailure(response.Errors);
-        }
-
-        return response;
+        await apiClient.DeleteAsync($"{Resource}/{id}",
+            onSuccess,
+            async response =>
+            {
+                if (onFailure != null) await onFailure(response.Errors);
+            });
     }
 }


### PR DESCRIPTION
## Summary
- update `IApiClient` to use callbacks and return `Task`
- revise `ApiClient` implementation for new signature
- adjust language and country services to forward callbacks
- update dialogs and lists to handle responses via callbacks

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d3ca9cd0832eb42cc4719fbee40e