### PR TITLE
Create generic CRUD service

### DIFF
--- a/Sakila.Web/Services/BaseCrudService.cs
+++ b/Sakila.Web/Services/BaseCrudService.cs
@@ -1,0 +1,89 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Components.Forms;
+using Sakila.Web.Abstractions;
+using Sakila.Web.Extensions;
+
+namespace Sakila.Web.Services;
+
+public abstract class BaseCrudService<TCreate, TUpdate, TGetAll, TGetById>
+{
+    private readonly IApiClient apiClient;
+    private readonly IValidator<TCreate> createValidator;
+    private readonly IValidator<TUpdate> updateValidator;
+    private readonly string resource;
+
+    protected BaseCrudService(
+        string resource,
+        IApiClient apiClient,
+        IValidator<TCreate> createValidator,
+        IValidator<TUpdate> updateValidator)
+    {
+        this.resource = resource;
+        this.apiClient = apiClient;
+        this.createValidator = createValidator;
+        this.updateValidator = updateValidator;
+    }
+
+    protected abstract int GetUpdateId(TUpdate request);
+
+    public EditContext EditContext { get; private set; } = null!;
+    public ValidationMessageStore MessageStore { get; private set; } = null!;
+
+    public void Initialize(object model)
+    {
+        EditContext = new EditContext(model);
+        MessageStore = new ValidationMessageStore(EditContext);
+    }
+
+    public async Task GetAllAsync(
+        Func<IApiResponse<TGetAll>, Task>? onSuccess = null,
+        Func<IApiResponse<TGetAll>, Task>? onFailure = null)
+    {
+        await apiClient.GetAsync(resource, onSuccess, onFailure);
+    }
+
+    public async Task GetByIdAsync(int id,
+        Func<IApiResponse<TGetById>, Task>? onSuccess = null,
+        Func<IApiResponse<TGetById>, Task>? onFailure = null)
+    {
+        await apiClient.GetAsync($"{resource}/{id}", onSuccess, onFailure);
+    }
+
+    public async Task CreateAsync(TCreate request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
+    {
+        await apiClient.PostAsync(resource, request, createValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
+    }
+
+    public async Task UpdateAsync(TUpdate request,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
+    {
+        await apiClient.PutAsync($"{resource}/{GetUpdateId(request)}", request, updateValidator,
+            onSuccess,
+            async response =>
+            {
+                EditContext.ApplyErrors(MessageStore, response);
+                if (onFailure != null) await onFailure(response.Errors);
+            });
+    }
+
+    public async Task DeleteAsync(int id,
+        Func<IApiResponse<object>, Task>? onSuccess = null,
+        Func<Dictionary<string, string[]>, Task>? onFailure = null)
+    {
+        await apiClient.DeleteAsync($"{resource}/{id}",
+            onSuccess,
+            async response =>
+            {
+                if (onFailure != null) await onFailure(response.Errors);
+            });
+    }
+}

--- a/Sakila.Web/Services/Implementations/CountryService.cs
+++ b/Sakila.Web/Services/Implementations/CountryService.cs
@@ -2,76 +2,16 @@ using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
-using Microsoft.AspNetCore.Components.Forms;
-using Sakila.Web.Extensions;
+using Sakila.Web.Services;
 
 namespace Sakila.Web.Services.Implementations;
 
 public class CountryService(
     IApiClient apiClient,
     IValidator<CountryCreateRequest> createValidator,
-    IValidator<CountryUpdateRequest> updateValidator) : ICountryService
+    IValidator<CountryUpdateRequest> updateValidator)
+    : BaseCrudService<CountryCreateRequest, CountryUpdateRequest, CountryGetAllResponse, CountryGetByIdResponse>(
+        "countries", apiClient, createValidator, updateValidator), ICountryService
 {
-    private const string Resource = "countries";
-
-    public EditContext EditContext { get; private set; } = null!;
-    public ValidationMessageStore MessageStore { get; private set; } = null!;
-
-    public void Initialize(object model)
-    {
-        EditContext = new EditContext(model);
-        MessageStore = new ValidationMessageStore(EditContext);
-    }
-
-    public async Task GetAllAsync(
-        Func<IApiResponse<CountryGetAllResponse>, Task>? onSuccess = null,
-        Func<IApiResponse<CountryGetAllResponse>, Task>? onFailure = null)
-    {
-        await apiClient.GetAsync(Resource, onSuccess, onFailure);
-    }
-
-    public async Task GetByIdAsync(int id,
-        Func<IApiResponse<CountryGetByIdResponse>, Task>? onSuccess = null,
-        Func<IApiResponse<CountryGetByIdResponse>, Task>? onFailure = null)
-    {
-        await apiClient.GetAsync($"{Resource}/{id}", onSuccess, onFailure);
-    }
-
-    public async Task CreateAsync(CountryCreateRequest request,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.PostAsync(Resource, request, createValidator,
-            onSuccess,
-            async response =>
-            {
-                EditContext.ApplyErrors(MessageStore, response);
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
-
-    public async Task UpdateAsync(CountryUpdateRequest request,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator,
-            onSuccess,
-            async response =>
-            {
-                EditContext.ApplyErrors(MessageStore, response);
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
-
-    public async Task DeleteAsync(int id,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.DeleteAsync($"{Resource}/{id}",
-            onSuccess,
-            async response =>
-            {
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
+    protected override int GetUpdateId(CountryUpdateRequest request) => request.Id;
 }

--- a/Sakila.Web/Services/Implementations/LanguageService.cs
+++ b/Sakila.Web/Services/Implementations/LanguageService.cs
@@ -2,76 +2,16 @@ using FluentValidation;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
-using Microsoft.AspNetCore.Components.Forms;
-using Sakila.Web.Extensions;
+using Sakila.Web.Services;
 
 namespace Sakila.Web.Services.Implementations;
 
 public class LanguageService(
     IApiClient apiClient,
     IValidator<LanguageCreateRequest> createValidator,
-    IValidator<LanguageUpdateRequest> updateValidator) : ILanguageService
+    IValidator<LanguageUpdateRequest> updateValidator)
+    : BaseCrudService<LanguageCreateRequest, LanguageUpdateRequest, LanguageGetAllResponse, LanguageGetByIdResponse>(
+        "languages", apiClient, createValidator, updateValidator), ILanguageService
 {
-    private const string Resource = "languages";
-
-    public EditContext EditContext { get; private set; } = null!;
-    public ValidationMessageStore MessageStore { get; private set; } = null!;
-
-    public void Initialize(object model)
-    {
-        EditContext = new EditContext(model);
-        MessageStore = new ValidationMessageStore(EditContext);
-    }
-
-    public async Task GetAllAsync(
-        Func<IApiResponse<LanguageGetAllResponse>, Task>? onSuccess = null,
-        Func<IApiResponse<LanguageGetAllResponse>, Task>? onFailure = null)
-    {
-        await apiClient.GetAsync(Resource, onSuccess, onFailure);
-    }
-
-    public async Task GetByIdAsync(int id,
-        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onSuccess = null,
-        Func<IApiResponse<LanguageGetByIdResponse>, Task>? onFailure = null)
-    {
-        await apiClient.GetAsync($"{Resource}/{id}", onSuccess, onFailure);
-    }
-
-    public async Task CreateAsync(LanguageCreateRequest request,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.PostAsync(Resource, request, createValidator,
-            onSuccess,
-            async response =>
-            {
-                EditContext.ApplyErrors(MessageStore, response);
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
-
-    public async Task UpdateAsync(LanguageUpdateRequest request,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.PutAsync($"{Resource}/{request.Id}", request, updateValidator,
-            onSuccess,
-            async response =>
-            {
-                EditContext.ApplyErrors(MessageStore, response);
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
-
-    public async Task DeleteAsync(int id,
-        Func<IApiResponse<object>, Task>? onSuccess = null,
-        Func<Dictionary<string, string[]>, Task>? onFailure = null)
-    {
-        await apiClient.DeleteAsync($"{Resource}/{id}",
-            onSuccess,
-            async response =>
-            {
-                if (onFailure != null) await onFailure(response.Errors);
-            });
-    }
+    protected override int GetUpdateId(LanguageUpdateRequest request) => request.Id;
 }


### PR DESCRIPTION
## Summary
- introduce a generic `BaseCrudService` implementing common CRUD logic
- refactor `CountryService` and `LanguageService` to derive from the base class

## Testing
- `dotnet test Sakila.Web/Sakila.Web.csproj --no-build --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d8f9c4d0832e9bfb68757a5936b8