### PR TITLE
Implement Fluxor store for dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Las interfaces `ILanguagesApi` e `ICountriesApi` definen los endpoints y Refit
 genera el código en tiempo de compilación. No es necesario ejecutar comandos
 adicionales: al compilar el proyecto los clientes se crean automáticamente.
 
+### Estado centralizado con Fluxor
+
+Para manejar la visibilidad de los diálogos y la entidad seleccionada se emplea
+el patrón **state store** mediante la librería [Fluxor](https://github.com/mrpm/Fluxor).
+Cada sección (`Countries`, `Languages`) dispone de un `*State` que expone las
+propiedades `IsCreateDialogOpen`, `IsUpdateDialogOpen`, `IsDeleteDialogOpen` y
+el modelo seleccionado. Las páginas despachan acciones para modificar el estado
+en lugar de mantener campos locales, logrando una UI más predecible.
+
 ---
 
 ## 📚 Referencias

--- a/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.Web/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Refit;
 using Sakila.Web.Abstractions;
 using Sakila.Web.Api;
 using Sakila.Web.Services.Implementations;
+using Fluxor;
 
 namespace Sakila.Web.Extensions;
 
@@ -30,6 +31,9 @@ public static class ServiceCollectionExtensions
         builder.Services.AddScoped<ICountryService, CountryService>();
         builder.Services.AddTransient<IValidator<CountryCreateRequest>, CountryCreateValidator>();
         builder.Services.AddTransient<IValidator<CountryUpdateRequest>, CountryUpdateValidator>();
+
+        builder.Services.AddFluxor(options =>
+            options.ScanAssemblies(typeof(ServiceCollectionExtensions).Assembly));
 
         return builder;
     }

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -1,5 +1,6 @@
 @page "/countries"
 @using Sakila.Web.Pages.Countries.Components
+@inject IState<CountryState> CountryState
 
 <h3>Countries</h3>
 
@@ -35,25 +36,25 @@ else
     </table>
 }
 
-@if (_isCreateDialogOpen)
+@if (CountryState.Value.IsCreateDialogOpen)
 {
     <CountryCreateDialog Visible="true"
                          OnCancel="CloseCreateDialog"
                          OnSuccess="OnCreateSuccess"/>
 }
 
-@if (_isUpdateDialogOpen)
+@if (CountryState.Value.IsUpdateDialogOpen)
 {
     <CountryUpdateDialog Visible="true"
-                         Country="_selectedCountry"
+                         Country="CountryState.Value.SelectedCountry"
                          OnCancel="CloseUpdateDialog"
                          OnSuccess="OnUpdateSuccess"/>
 }
 
-@if (_isDeleteDialogOpen)
+@if (CountryState.Value.IsDeleteDialogOpen)
 {
     <ConfirmDelete Visible="true"
-                  Country="_selectedCountry"
+                  Country="CountryState.Value.SelectedCountry"
                   OnCancel="CloseDeleteDialog"
                   OnSuccess="OnDeleteSuccess"/>
 }

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -1,16 +1,16 @@
 using Microsoft.AspNetCore.Components;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Fluxor;
+using Sakila.Web.Store.Countries;
 
 namespace Sakila.Web.Pages.Countries;
 
 public partial class List
 {
     private IApiResponse<CountryGetAllResponse>? _getAllResponse;
-    private bool _isDeleteDialogOpen;
-    private bool _isCreateDialogOpen;
-    private bool _isUpdateDialogOpen;
-    private CountryGetByIdResponse _selectedCountry = new();
+    [Inject] public IState<CountryState> CountryState { get; set; } = null!;
+    [Inject] public IDispatcher Dispatcher { get; set; } = null!;
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -20,35 +20,34 @@ public partial class List
 
     private void ShowCreateDialog()
     {
-        _isCreateDialogOpen = true;
+        Dispatcher.Dispatch(new ShowCreateDialogAction());
     }
 
     private void ShowUpdateDialog(CountryGetByIdResponse country)
     {
-        _selectedCountry = country;
-        _isUpdateDialogOpen = true;
+        Dispatcher.Dispatch(new ShowUpdateDialogAction(country));
     }
 
     private void CloseCreateDialog()
     {
-        _isCreateDialogOpen = false;
+        Dispatcher.Dispatch(new CloseCreateDialogAction());
     }
 
     private void CloseUpdateDialog()
     {
-        _isUpdateDialogOpen = false;
+        Dispatcher.Dispatch(new CloseUpdateDialogAction());
     }
 
     private async Task OnCreateSuccess()
     {
         await RefreshCountries();
-        CloseCreateDialog();
+        Dispatcher.Dispatch(new CloseCreateDialogAction());
     }
 
     private async Task OnUpdateSuccess()
     {
         await RefreshCountries();
-        CloseUpdateDialog();
+        Dispatcher.Dispatch(new CloseUpdateDialogAction());
     }
 
     private async Task RefreshCountries()
@@ -59,18 +58,17 @@ public partial class List
 
     private void ShowDeleteDialog(CountryGetByIdResponse country)
     {
-        _selectedCountry = country;
-        _isDeleteDialogOpen = true;
+        Dispatcher.Dispatch(new ShowDeleteDialogAction(country));
     }
 
     private void CloseDeleteDialog()
     {
-        _isDeleteDialogOpen = false;
+        Dispatcher.Dispatch(new CloseDeleteDialogAction());
     }
 
     private async Task OnDeleteSuccess()
     {
         await RefreshCountries();
-        CloseDeleteDialog();
+        Dispatcher.Dispatch(new CloseDeleteDialogAction());
     }
 }

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -1,5 +1,6 @@
 @page "/languages"
 @using Sakila.Web.Pages.Languages.Components
+@inject IState<LanguageState> LanguageState
 
 <h3>Languages</h3>
 
@@ -35,25 +36,25 @@ else
     </table>
 }
 
-@if (_isCreateDialogOpen)
+@if (LanguageState.Value.IsCreateDialogOpen)
 {
     <LanguageCreateDialog Visible="true"
                           OnCancel="CloseCreateDialog"
                           OnSuccess="OnCreateSuccess"/>
 }
 
-@if (_isUpdateDialogOpen)
+@if (LanguageState.Value.IsUpdateDialogOpen)
 {
     <LanguageUpdateDialog Visible="true"
-                          Language="_selectedLanguage"
-                          OnCancel="CloseUpdateDialog"
-                          OnSuccess="OnUpdateSuccess"/>
+                         Language="LanguageState.Value.SelectedLanguage"
+                         OnCancel="CloseUpdateDialog"
+                         OnSuccess="OnUpdateSuccess"/>
 }
 
-@if (_isDeleteDialogOpen)
+@if (LanguageState.Value.IsDeleteDialogOpen)
 {
     <ConfirmDelete Visible="true"
-                  Language="_selectedLanguage"
+                  Language="LanguageState.Value.SelectedLanguage"
                   OnCancel="CloseDeleteDialog"
                   OnSuccess="OnDeleteSuccess"/>
 }

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -1,16 +1,16 @@
 using Microsoft.AspNetCore.Components;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
+using Fluxor;
+using Sakila.Web.Store.Languages;
 
 namespace Sakila.Web.Pages.Languages;
 
 public partial class List
 {
     private IApiResponse<LanguageGetAllResponse>? _getAllResponse;
-    private bool _isDeleteDialogOpen;
-    private bool _isCreateDialogOpen;
-    private bool _isUpdateDialogOpen;
-    private LanguageGetByIdResponse _selectedLanguage = new();
+    [Inject] public IState<LanguageState> LanguageState { get; set; } = null!;
+    [Inject] public IDispatcher Dispatcher { get; set; } = null!;
     [Inject] public ILanguageService LanguageService { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
@@ -20,35 +20,34 @@ public partial class List
 
     private void ShowCreateDialog()
     {
-        _isCreateDialogOpen = true;
+        Dispatcher.Dispatch(new ShowCreateDialogAction());
     }
 
     private void ShowUpdateDialog(LanguageGetByIdResponse language)
     {
-        _selectedLanguage = language;
-        _isUpdateDialogOpen = true;
+        Dispatcher.Dispatch(new ShowUpdateDialogAction(language));
     }
 
     private void CloseCreateDialog()
     {
-        _isCreateDialogOpen = false;
+        Dispatcher.Dispatch(new CloseCreateDialogAction());
     }
 
     private void CloseUpdateDialog()
     {
-        _isUpdateDialogOpen = false;
+        Dispatcher.Dispatch(new CloseUpdateDialogAction());
     }
 
     private async Task OnCreateSuccess()
     {
         await RefreshLanguages();
-        CloseCreateDialog();
+        Dispatcher.Dispatch(new CloseCreateDialogAction());
     }
 
     private async Task OnUpdateSuccess()
     {
         await RefreshLanguages();
-        CloseUpdateDialog();
+        Dispatcher.Dispatch(new CloseUpdateDialogAction());
     }
 
     private async Task RefreshLanguages()
@@ -59,18 +58,17 @@ public partial class List
 
     private void ShowDeleteDialog(LanguageGetByIdResponse language)
     {
-        _selectedLanguage = language;
-        _isDeleteDialogOpen = true;
+        Dispatcher.Dispatch(new ShowDeleteDialogAction(language));
     }
 
     private void CloseDeleteDialog()
     {
-        _isDeleteDialogOpen = false;
+        Dispatcher.Dispatch(new CloseDeleteDialogAction());
     }
 
     private async Task OnDeleteSuccess()
     {
         await RefreshLanguages();
-        CloseDeleteDialog();
+        Dispatcher.Dispatch(new CloseDeleteDialogAction());
     }
 }

--- a/Sakila.Web/Sakila.Web.csproj
+++ b/Sakila.Web/Sakila.Web.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.2.0" />
+    <PackageReference Include="Fluxor.Blazor.Web" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sakila.Web/Store/Countries/CountryState.cs
+++ b/Sakila.Web/Store/Countries/CountryState.cs
@@ -1,0 +1,52 @@
+using Fluxor;
+using Sakila.Contracts.Countries.Queries.Responses;
+
+namespace Sakila.Web.Store.Countries;
+
+public record CountryState(
+    bool IsCreateDialogOpen,
+    bool IsUpdateDialogOpen,
+    bool IsDeleteDialogOpen,
+    CountryGetByIdResponse SelectedCountry);
+
+public class CountryFeature : Feature<CountryState>
+{
+    public override string GetName() => "Country";
+
+    protected override CountryState GetInitialState() =>
+        new(false, false, false, new());
+}
+
+public record ShowCreateDialogAction;
+public record CloseCreateDialogAction;
+public record ShowUpdateDialogAction(CountryGetByIdResponse Country);
+public record CloseUpdateDialogAction;
+public record ShowDeleteDialogAction(CountryGetByIdResponse Country);
+public record CloseDeleteDialogAction;
+
+public static class CountryReducers
+{
+    [ReducerMethod]
+    public static CountryState ReduceShowCreateDialog(CountryState state, ShowCreateDialogAction action) =>
+        state with { IsCreateDialogOpen = true };
+
+    [ReducerMethod]
+    public static CountryState ReduceCloseCreateDialog(CountryState state, CloseCreateDialogAction action) =>
+        state with { IsCreateDialogOpen = false };
+
+    [ReducerMethod]
+    public static CountryState ReduceShowUpdateDialog(CountryState state, ShowUpdateDialogAction action) =>
+        state with { IsUpdateDialogOpen = true, SelectedCountry = action.Country };
+
+    [ReducerMethod]
+    public static CountryState ReduceCloseUpdateDialog(CountryState state, CloseUpdateDialogAction action) =>
+        state with { IsUpdateDialogOpen = false };
+
+    [ReducerMethod]
+    public static CountryState ReduceShowDeleteDialog(CountryState state, ShowDeleteDialogAction action) =>
+        state with { IsDeleteDialogOpen = true, SelectedCountry = action.Country };
+
+    [ReducerMethod]
+    public static CountryState ReduceCloseDeleteDialog(CountryState state, CloseDeleteDialogAction action) =>
+        state with { IsDeleteDialogOpen = false };
+}

--- a/Sakila.Web/Store/Languages/LanguageState.cs
+++ b/Sakila.Web/Store/Languages/LanguageState.cs
@@ -1,0 +1,52 @@
+using Fluxor;
+using Sakila.Contracts.Languages.Queries.Responses;
+
+namespace Sakila.Web.Store.Languages;
+
+public record LanguageState(
+    bool IsCreateDialogOpen,
+    bool IsUpdateDialogOpen,
+    bool IsDeleteDialogOpen,
+    LanguageGetByIdResponse SelectedLanguage);
+
+public class LanguageFeature : Feature<LanguageState>
+{
+    public override string GetName() => "Language";
+
+    protected override LanguageState GetInitialState() =>
+        new(false, false, false, new());
+}
+
+public record ShowCreateDialogAction;
+public record CloseCreateDialogAction;
+public record ShowUpdateDialogAction(LanguageGetByIdResponse Language);
+public record CloseUpdateDialogAction;
+public record ShowDeleteDialogAction(LanguageGetByIdResponse Language);
+public record CloseDeleteDialogAction;
+
+public static class LanguageReducers
+{
+    [ReducerMethod]
+    public static LanguageState ReduceShowCreateDialog(LanguageState state, ShowCreateDialogAction action) =>
+        state with { IsCreateDialogOpen = true };
+
+    [ReducerMethod]
+    public static LanguageState ReduceCloseCreateDialog(LanguageState state, CloseCreateDialogAction action) =>
+        state with { IsCreateDialogOpen = false };
+
+    [ReducerMethod]
+    public static LanguageState ReduceShowUpdateDialog(LanguageState state, ShowUpdateDialogAction action) =>
+        state with { IsUpdateDialogOpen = true, SelectedLanguage = action.Language };
+
+    [ReducerMethod]
+    public static LanguageState ReduceCloseUpdateDialog(LanguageState state, CloseUpdateDialogAction action) =>
+        state with { IsUpdateDialogOpen = false };
+
+    [ReducerMethod]
+    public static LanguageState ReduceShowDeleteDialog(LanguageState state, ShowDeleteDialogAction action) =>
+        state with { IsDeleteDialogOpen = true, SelectedLanguage = action.Language };
+
+    [ReducerMethod]
+    public static LanguageState ReduceCloseDeleteDialog(LanguageState state, CloseDeleteDialogAction action) =>
+        state with { IsDeleteDialogOpen = false };
+}

--- a/Sakila.Web/_Imports.razor
+++ b/Sakila.Web/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using Sakila.Web
 @using Sakila.Web.Layout
+@using Fluxor


### PR DESCRIPTION
## Summary
- evaluate Fluxor for state management
- add centralized CountryState and LanguageState
- dispatch actions from Countries and Languages pages
- register Fluxor in DI
- document the state store approach in README

## Testing
- `dotnet build CRUD-DSC.sln -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e3681bd0832eb9ed736059b99e6f