### PR TITLE
Fix Country/Language list injection and state access

### DIFF
--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -1,7 +1,6 @@
 @page "/countries"
 @using Sakila.Web.Pages.Countries.Components
 @using Sakila.Web.Store.Countries
-@inject IState<CountryState> CountryState
 
 <h3>Countries</h3>
 
@@ -37,25 +36,25 @@ else
     </table>
 }
 
-@if (Web.Store.Countries.CountryState.Value.IsCreateDialogOpen)
+@if (CountryState.Value.IsCreateDialogOpen)
 {
     <CountryCreateDialog Visible="true"
                          OnCancel="CloseCreateDialog"
                          OnSuccess="OnCreateSuccess"/>
 }
 
-@if (Web.Store.Countries.CountryState.Value.IsUpdateDialogOpen)
+@if (CountryState.Value.IsUpdateDialogOpen)
 {
     <CountryUpdateDialog Visible="true"
-                         Country="Web.Store.Countries.CountryState.Value.SelectedCountry"
+                         Country="CountryState.Value.SelectedCountry"
                          OnCancel="CloseUpdateDialog"
                          OnSuccess="OnUpdateSuccess"/>
 }
 
-@if (Web.Store.Countries.CountryState.Value.IsDeleteDialogOpen)
+@if (CountryState.Value.IsDeleteDialogOpen)
 {
     <ConfirmDelete Visible="true"
-                  Country="Web.Store.Countries.CountryState.Value.SelectedCountry"
+                  Country="CountryState.Value.SelectedCountry"
                   OnCancel="CloseDeleteDialog"
                   OnSuccess="OnDeleteSuccess"/>
 }

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -1,7 +1,6 @@
 @page "/languages"
 @using Sakila.Web.Pages.Languages.Components
 @using Sakila.Web.Store.Languages
-@inject IState<LanguageState> LanguageState
 
 <h3>Languages</h3>
 
@@ -37,25 +36,25 @@ else
     </table>
 }
 
-@if (Web.Store.Languages.LanguageState.Value.IsCreateDialogOpen)
+@if (LanguageState.Value.IsCreateDialogOpen)
 {
     <LanguageCreateDialog Visible="true"
                           OnCancel="CloseCreateDialog"
                           OnSuccess="OnCreateSuccess"/>
 }
 
-@if (Web.Store.Languages.LanguageState.Value.IsUpdateDialogOpen)
+@if (LanguageState.Value.IsUpdateDialogOpen)
 {
     <LanguageUpdateDialog Visible="true"
-                         Language="Web.Store.Languages.LanguageState.Value.SelectedLanguage"
+                         Language="LanguageState.Value.SelectedLanguage"
                          OnCancel="CloseUpdateDialog"
                          OnSuccess="OnUpdateSuccess"/>
 }
 
-@if (Web.Store.Languages.LanguageState.Value.IsDeleteDialogOpen)
+@if (LanguageState.Value.IsDeleteDialogOpen)
 {
     <ConfirmDelete Visible="true"
-                  Language="Web.Store.Languages.LanguageState.Value.SelectedLanguage"
+                  Language="LanguageState.Value.SelectedLanguage"
                   OnCancel="CloseDeleteDialog"
                   OnSuccess="OnDeleteSuccess"/>
 }


### PR DESCRIPTION
## Summary
- remove duplicate `@inject` directives from Country and Language lists
- reference Fluxor state via injected properties

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849e512a38c832e857b93817832af17