### PR TITLE
Integrate MudBlazor components

### DIFF
--- a/Sakila.Web/App.razor
+++ b/Sakila.Web/App.razor
@@ -1,12 +1,15 @@
-<Router AppAssembly="@typeof(App).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
-    </Found>
-    <NotFound>
-        <PageTitle>Not found</PageTitle>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+<MudThemeProvider>
+    <MudDialogProvider />
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</MudThemeProvider>

--- a/Sakila.Web/Layout/MainLayout.razor
+++ b/Sakila.Web/Layout/MainLayout.razor
@@ -1,16 +1,25 @@
 @inherits LayoutComponentBase
-<div class="page">
-    <div class="sidebar">
-        <NavMenu/>
-    </div>
 
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
+<MudLayout>
+    <MudAppBar Color="Color.Primary">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
+        <MudText Typo="Typo.h6" Class="px-2">Sakila.Web</MudText>
+        <MudSpacer />
+        <MudButton Variant="Variant.Text" Href="https://learn.microsoft.com/aspnet/core/" Target="_blank">About</MudButton>
+    </MudAppBar>
 
-        <article class="content px-4">
+    <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1">
+        <NavMenu />
+    </MudDrawer>
+
+    <MudMainContent>
+        <div class="px-4">
             @Body
-        </article>
-    </main>
-</div>
+        </div>
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private bool _drawerOpen = true;
+    private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
+}

--- a/Sakila.Web/Layout/NavMenu.razor
+++ b/Sakila.Web/Layout/NavMenu.razor
@@ -1,28 +1,5 @@
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">Sakila.Web</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    </div>
-</div>
-
-<div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
-    <nav class="nav flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="languages">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Languages
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="countries">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Countries
-            </NavLink>
-        </div>
-    </nav>
-</div>
+<MudNavMenu>
+    <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+    <MudNavLink Href="languages" Icon="@Icons.Material.Filled.Language">Languages</MudNavLink>
+    <MudNavLink Href="countries" Icon="@Icons.Material.Filled.Public">Countries</MudNavLink>
+</MudNavMenu>

--- a/Sakila.Web/Layout/NavMenu.razor.cs
+++ b/Sakila.Web/Layout/NavMenu.razor.cs
@@ -2,11 +2,4 @@ namespace Sakila.Web.Layout;
 
 public partial class NavMenu
 {
-    private bool _collapseNavMenu = true;
-    private string? NavMenuCssClass => _collapseNavMenu ? "collapse" : null;
-
-    private void ToggleNavMenu()
-    {
-        _collapseNavMenu = !_collapseNavMenu;
-    }
 }

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -1,19 +1,13 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Confirm Deletion</h5>
-                </div>
-                <div class="modal-body">
-                    <p>Are you sure you want to delete <strong>@Country.Name</strong>?</p>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" @onclick="OnCancel">No</button>
-                    <button class="btn btn-danger" @onclick="ConfirmAsync">Yes</button>
-                </div>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.ExtraSmall" FullWidth="true">
+        <DialogContent>
+            <MudText Typo="Typo.h6">Confirm Deletion</MudText>
+            <MudText>Are you sure you want to delete <strong>@Country.Name</strong>?</MudText>
+        </DialogContent>
+        <DialogActions>
+            <MudButton Color="Color.Secondary" OnClick="OnCancel">No</MudButton>
+            <MudButton Color="Color.Error" OnClick="ConfirmAsync">Yes</MudButton>
+        </DialogActions>
+    </MudDialog>
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -1,23 +1,16 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Add Country</h5>
-                    </div>
-                    <div class="modal-body">
-                        <DataAnnotationsValidator/>
-                        <InputText class="form-control" @bind-Value="Country.Name" placeholder="Country Name"/>
-                        <ValidationMessage For="@(() => Country.Name)"/>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">Add</button>
-                    </div>
-                </EditForm>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
+        <MudForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+            <DialogContent>
+                <MudDialogTitle>Add Country</MudDialogTitle>
+                <DataAnnotationsValidator />
+                <MudTextField @bind-Value="Country.Name" Label="Country Name" For="@(() => Country.Name)" Required="true" />
+            </DialogContent>
+            <DialogActions>
+                <MudButton Color="Color.Secondary" OnClick="OnCancel">Cancel</MudButton>
+                <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
+            </DialogActions>
+        </MudForm>
+    </MudDialog>
 }

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -1,24 +1,17 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Edit Country</h5>
-                    </div>
-                    <div class="modal-body">
-                        <DataAnnotationsValidator />
-                        <InputText class="form-control" @bind-Value="Model.Name" placeholder="Country Name" />
-                        <ValidationMessage For="@(() => Model.Name)" />
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">Edit</button>
-                    </div>
-                </EditForm>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
+        <MudForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+            <DialogContent>
+                <MudDialogTitle>Edit Country</MudDialogTitle>
+                <DataAnnotationsValidator />
+                <MudTextField @bind-Value="Model.Name" Label="Country Name" For="@(() => Model.Name)" Required="true" />
+            </DialogContent>
+            <DialogActions>
+                <MudButton Color="Color.Secondary" OnClick="OnCancel">Cancel</MudButton>
+                <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
+            </DialogActions>
+        </MudForm>
+    </MudDialog>
 }
 

--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -2,38 +2,29 @@
 @using Sakila.Web.Pages.Countries.Components
 @using Sakila.Web.Store.Countries
 
-<h3>Countries</h3>
+<MudText Typo="Typo.h3">Countries</MudText>
 
-<button class="btn btn-primary mb-3" @onclick="ShowCreateDialog">Add Country</button>
+<MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="ShowCreateDialog">Add Country</MudButton>
 
 @if (_getAllResponse?.Data?.Countries == null)
 {
-    <p>
-        <em>Loading...</em>
-    </p>
+    <MudProgressCircular Indeterminate="true" />
 }
 else
 {
-    <table class="table table-striped">
-        <thead>
-        <tr>
-            <th>Name</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @foreach (var country in _getAllResponse.Data!.Countries)
-        {
-            <tr>
-                <td>@country.Name</td>
-                <td>
-                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowUpdateDialog(country)">Edit</button>
-                    <button class="btn btn-sm btn-danger" @onclick="() => ShowDeleteDialog(country)">Delete</button>
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
+    <MudTable Items="_getAllResponse.Data!.Countries">
+        <HeaderContent>
+            <MudTh>Name</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd>
+                <MudButton Size="Size.Small" Color="Color.Warning" Variant="Variant.Text" OnClick="() => ShowUpdateDialog(context)" Class="me-1">Edit</MudButton>
+                <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Text" OnClick="() => ShowDeleteDialog(context)">Delete</MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 }
 
 @if (CountryState.Value.IsCreateDialogOpen)

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -1,19 +1,13 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Confirm Deletion</h5>
-                </div>
-                <div class="modal-body">
-                    <p>Are you sure you want to delete <strong>@Language.Name</strong>?</p>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-secondary" @onclick="OnCancel">No</button>
-                    <button class="btn btn-danger" @onclick="ConfirmAsync">Yes</button>
-                </div>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.ExtraSmall" FullWidth="true">
+        <DialogContent>
+            <MudText Typo="Typo.h6">Confirm Deletion</MudText>
+            <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
+        </DialogContent>
+        <DialogActions>
+            <MudButton Color="Color.Secondary" OnClick="OnCancel">No</MudButton>
+            <MudButton Color="Color.Error" OnClick="ConfirmAsync">Yes</MudButton>
+        </DialogActions>
+    </MudDialog>
 }

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -1,24 +1,17 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Add Language</h5>
-                    </div>
-                    <div class="modal-body">
-                        <DataAnnotationsValidator />
-                        <InputText class="form-control" @bind-Value="Language.Name" placeholder="Language Name" />
-                        <ValidationMessage For="@(() => Language.Name)" />
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">Add</button>
-                    </div>
-                </EditForm>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
+        <MudForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
+            <DialogContent>
+                <MudDialogTitle>Add Language</MudDialogTitle>
+                <DataAnnotationsValidator />
+                <MudTextField @bind-Value="Language.Name" Label="Language Name" For="@(() => Language.Name)" Required="true" />
+            </DialogContent>
+            <DialogActions>
+                <MudButton Color="Color.Secondary" OnClick="OnCancel">Cancel</MudButton>
+                <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
+            </DialogActions>
+        </MudForm>
+    </MudDialog>
 }
 

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -1,23 +1,16 @@
 @if (Visible)
 {
-    <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Edit Language</h5>
-                    </div>
-                    <div class="modal-body">
-                        <DataAnnotationsValidator/>
-                        <InputText class="form-control" @bind-Value="Model.Name" placeholder="Language Name"/>
-                        <ValidationMessage For="@(() => Model.Name)"/>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" @onclick="OnCancel">Cancel</button>
-                        <button type="submit" class="btn btn-primary">Edit</button>
-                    </div>
-                </EditForm>
-            </div>
-        </div>
-    </div>
+    <MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
+        <MudForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
+            <DialogContent>
+                <MudDialogTitle>Edit Language</MudDialogTitle>
+                <DataAnnotationsValidator />
+                <MudTextField @bind-Value="Model.Name" Label="Language Name" For="@(() => Model.Name)" Required="true" />
+            </DialogContent>
+            <DialogActions>
+                <MudButton Color="Color.Secondary" OnClick="OnCancel">Cancel</MudButton>
+                <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
+            </DialogActions>
+        </MudForm>
+    </MudDialog>
 }

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -2,38 +2,29 @@
 @using Sakila.Web.Pages.Languages.Components
 @using Sakila.Web.Store.Languages
 
-<h3>Languages</h3>
+<MudText Typo="Typo.h3">Languages</MudText>
 
-<button class="btn btn-primary mb-3" @onclick="ShowCreateDialog">Add Language</button>
+<MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="ShowCreateDialog">Add Language</MudButton>
 
 @if (_getAllResponse?.Data?.Languages == null)
 {
-    <p>
-        <em>Loading...</em>
-    </p>
+    <MudProgressCircular Indeterminate="true" />
 }
 else
 {
-    <table class="table table-striped">
-        <thead>
-        <tr>
-            <th>Name</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @foreach (var language in _getAllResponse.Data!.Languages)
-        {
-            <tr>
-                <td>@language.Name</td>
-                <td>
-                    <button class="btn btn-sm btn-warning me-1" @onclick="() => ShowUpdateDialog(language)">Edit</button>
-                    <button class="btn btn-sm btn-danger" @onclick="() => ShowDeleteDialog(language)">Delete</button>
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
+    <MudTable Items="_getAllResponse.Data!.Languages">
+        <HeaderContent>
+            <MudTh>Name</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd>
+                <MudButton Size="Size.Small" Color="Color.Warning" Variant="Variant.Text" OnClick="() => ShowUpdateDialog(context)" Class="me-1">Edit</MudButton>
+                <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Text" OnClick="() => ShowDeleteDialog(context)">Delete</MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 }
 
 @if (LanguageState.Value.IsCreateDialogOpen)

--- a/Sakila.Web/Program.cs
+++ b/Sakila.Web/Program.cs
@@ -2,11 +2,13 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Sakila.Web;
 using Sakila.Web.Extensions;
+using MudBlazor.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.AddSakilaServices();
+builder.Services.AddMudServices();
 
 await builder.Build().RunAsync();

--- a/Sakila.Web/Sakila.Web.csproj
+++ b/Sakila.Web/Sakila.Web.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.2.0" />
     <PackageReference Include="Fluxor.Blazor.Web" Version="6.0.1" />
+    <PackageReference Include="MudBlazor" Version="6.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sakila.Web/_Imports.razor
+++ b/Sakila.Web/_Imports.razor
@@ -9,3 +9,4 @@
 @using Sakila.Web
 @using Sakila.Web.Layout
 @using Fluxor
+@using MudBlazor

--- a/Sakila.Web/wwwroot/index.html
+++ b/Sakila.Web/wwwroot/index.html
@@ -7,6 +7,7 @@
     <title>Sakila.Web</title>
     <base href="/"/>
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css"/>
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="css/app.css"/>
     <link rel="icon" type="image/png" href="favicon.png"/>
     <link href="Sakila.Web.styles.css" rel="stylesheet"/>
@@ -27,6 +28,7 @@
     <span class="dismiss">🗙</span>
 </div>
 <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+<script src="_content/MudBlazor/MudBlazor.min.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- add MudBlazor package and service initialization
- include MudBlazor static assets
- use MudBlazor layout and navigation
- migrate dialogs and tables to MudBlazor components

## Testing
- `dotnet build Sakila.Web/Sakila.Web.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5fc3184832e8e25ebe9cac3aa09