### PR TITLE
Fix MudThemeProvider usage

### DIFF
--- a/Sakila.Web/App.razor
+++ b/Sakila.Web/App.razor
@@ -1,6 +1,6 @@
-<MudThemeProvider>
-    <MudDialogProvider/>
-    <Router AppAssembly="@typeof(App).Assembly">
+<MudThemeProvider />
+<MudDialogProvider />
+<Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
             <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
             <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
@@ -12,4 +12,4 @@
             </LayoutView>
         </NotFound>
     </Router>
-</MudThemeProvider>
+


### PR DESCRIPTION
## Summary
- update App.razor to use the current MudBlazor `MudThemeProvider`

## Testing
- `dotnet build CRUD-DSC.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ea3ba508832eb7aad38d81757ecb