### PR TITLE
Fix MudBlazor dialog provider

### DIFF
--- a/Sakila.Web/App.razor
+++ b/Sakila.Web/App.razor
@@ -1,6 +1,6 @@
-<MudThemeProvider />
-<MudDialogProvider />
-<Router AppAssembly="@typeof(App).Assembly">
+<MudThemeProvider>
+    <MudDialogProvider />
+    <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
             <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
             <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
@@ -12,4 +12,5 @@
             </LayoutView>
         </NotFound>
     </Router>
+</MudThemeProvider>
 


### PR DESCRIPTION
## Summary
- wrap `App.razor` contents within `MudThemeProvider`

## Testing
- `dotnet build CRUD-DSC.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb4e871c832e86dabd19093a515b