### PR TITLE
Fix base component for Countries and Languages lists

### DIFF
--- a/Sakila.Web/Pages/Countries/List.razor
+++ b/Sakila.Web/Pages/Countries/List.razor
@@ -1,5 +1,6 @@
 @page "/countries"
 @using Sakila.Web.Pages.Countries.Components
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <MudText Typo="Typo.h3">Countries</MudText>
 

--- a/Sakila.Web/Pages/Languages/List.razor
+++ b/Sakila.Web/Pages/Languages/List.razor
@@ -1,5 +1,6 @@
 @page "/languages"
 @using Sakila.Web.Pages.Languages.Components
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <MudText Typo="Typo.h3">Languages</MudText>
 


### PR DESCRIPTION
## Summary
- align partial component base classes for Countries and Languages lists

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef548ed8832e98590eaafb4cb7f5