### PR TITLE
Fix language dialogs closing

### DIFF
--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -13,12 +13,16 @@ public partial class ConfirmDelete
 
     private async Task ConfirmAsync()
     {
+        var success = false;
         await LanguageService.DeleteAsync(Language.Id,
             _ =>
             {
-                MudDialog.Close(DialogResult.Ok(true));
+                success = true;
                 return Task.CompletedTask;
             });
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor.cs
@@ -19,13 +19,16 @@ public partial class LanguageCreateDialog
 
     private async Task SubmitAsync()
     {
+        var success = false;
         await LanguageService.CreateAsync(Language,
             _ =>
             {
-                MudDialog.Close(DialogResult.Ok(true));
+                success = true;
                 return Task.CompletedTask;
-            }
-        );
+            });
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor.cs
@@ -22,12 +22,16 @@ public partial class LanguageUpdateDialog
 
     private async Task SubmitAsync()
     {
+        var success = false;
         await LanguageService.UpdateAsync(Model,
             _ =>
             {
-                MudDialog.Close(DialogResult.Ok(true));
+                success = true;
                 return Task.CompletedTask;
             });
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -25,8 +25,9 @@ namespace Sakila.Web.Pages.Languages
 
         private async Task ShowCreateDialog()
         {
-            var dialog = await DialogService.ShowAsync<LanguageCreateDialog>("Add Language");
-            if (!dialog.Result.IsCompleted)
+            var dialog = DialogService.Show<LanguageCreateDialog>("Add Language");
+            var result = await dialog.Result;
+            if (!result.Cancelled)
             {
                 await RefreshLanguages();
             }
@@ -35,8 +36,9 @@ namespace Sakila.Web.Pages.Languages
         private async Task ShowUpdateDialog(LanguageGetByIdResponse language)
         {
             var parameters = new DialogParameters { [nameof(LanguageUpdateDialog.Language)] = language };
-            var dialog = DialogService.ShowAsync<LanguageUpdateDialog>("Edit Language", parameters);
-            if (!dialog.IsCompleted)
+            var dialog = DialogService.Show<LanguageUpdateDialog>("Edit Language", parameters);
+            var result = await dialog.Result;
+            if (!result.Cancelled)
             {
                 await RefreshLanguages();
             }
@@ -45,8 +47,9 @@ namespace Sakila.Web.Pages.Languages
         private async Task ShowDeleteDialog(LanguageGetByIdResponse language)
         {
             var parameters = new DialogParameters { [nameof(ConfirmDelete.Language)] = language };
-            var dialog = DialogService.ShowAsync<ConfirmDelete>("Delete Language", parameters);
-            if (!dialog.IsCompleted)
+            var dialog = DialogService.Show<ConfirmDelete>("Delete Language", parameters);
+            var result = await dialog.Result;
+            if (!result.Cancelled)
             {
                 await RefreshLanguages();
             }


### PR DESCRIPTION
## Summary
- close language dialogs only when CRUD operations succeed
- wait for dialog results before refreshing list

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a044081bc832ebdaa3bb1b8e5071e