### PR TITLE
Sync country dialogs with language fixes

### DIFF
--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -1,4 +1,4 @@
-<MudDialog MaxWidth="MaxWidth.ExtraSmall" FullWidth="true">
+<MudDialog>
     <DialogContent>
         <MudText Typo="Typo.h6">Confirm Deletion</MudText>
         <MudText>Are you sure you want to delete <strong>@Country.Name</strong>?</MudText>
@@ -8,3 +8,4 @@
         <MudButton Color="Color.Error" OnClick="ConfirmAsync">Yes</MudButton>
     </DialogActions>
 </MudDialog>
+

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor.cs
@@ -11,17 +11,18 @@ public partial class ConfirmDelete
     [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
-    public IApiResponse<object>? ApiResponse { get; set; }
-
     private async Task ConfirmAsync()
     {
+        var success = false;
         await CountryService.DeleteAsync(Country.Id,
-            response =>
+            _ =>
             {
-                ApiResponse = response;
+                success = true;
                 return Task.CompletedTask;
             });
-        MudDialog.Close(DialogResult.Ok(true));
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -1,13 +1,13 @@
-<MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
-    <MudForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+<EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudDialog>
         <DialogContent>
-            <MudDialogTitle>Add Country</MudDialogTitle>
-            <DataAnnotationsValidator/>
-            <MudTextField @bind-Value="Country.Name" Label="Country Name" For="@(() => Country.Name)" Required="true"/>
+            <MudTextField @bind-Value="Country.Name" Label="Country Name" For="@(() => Country.Name)" Required="true" />
+            <DataAnnotationsValidator />
         </DialogContent>
         <DialogActions>
             <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
             <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
         </DialogActions>
-    </MudForm>
-</MudDialog>
+    </MudDialog>
+</EditForm>
+

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor.cs
@@ -10,7 +10,6 @@ public partial class CountryCreateDialog
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
-    public IApiResponse<object>? ApiResponse { get; set; }
     private CountryCreateRequest Country { get; } = new();
 
     protected override void OnInitialized()
@@ -20,13 +19,16 @@ public partial class CountryCreateDialog
 
     private async Task SubmitAsync()
     {
+        var success = false;
         await CountryService.CreateAsync(Country,
-            response =>
+            _ =>
             {
-                ApiResponse = response;
+                success = true;
                 return Task.CompletedTask;
             });
-        MudDialog.Close(DialogResult.Ok(true));
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -1,13 +1,14 @@
-<MudDialog MaxWidth="MaxWidth.Small" FullWidth="true">
-    <MudForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+<EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudDialog>
         <DialogContent>
-            <MudDialogTitle>Edit Country</MudDialogTitle>
-            <DataAnnotationsValidator/>
-            <MudTextField @bind-Value="Model.Name" Label="Country Name" For="@(() => Model.Name)" Required="true"/>
+            <MudText Typo="Typo.h6">Edit Country</MudText>
+            <MudTextField @bind-Value="Model.Name" Label="Country Name" For="@(() => Model.Name)" Required="true" />
+            <DataAnnotationsValidator />
         </DialogContent>
         <DialogActions>
             <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
             <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
         </DialogActions>
-    </MudForm>
-</MudDialog>
+    </MudDialog>
+</EditForm>
+

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor.cs
@@ -12,7 +12,6 @@ public partial class CountryUpdateDialog
     [Parameter] public CountryGetByIdResponse Country { get; set; } = new();
     [Inject] public ICountryService CountryService { get; set; } = null!;
 
-    public IApiResponse<object>? ApiResponse { get; set; }
     private CountryUpdateRequest Model { get; set; } = new();
 
     protected override void OnParametersSet()
@@ -23,13 +22,16 @@ public partial class CountryUpdateDialog
 
     private async Task SubmitAsync()
     {
+        var success = false;
         await CountryService.UpdateAsync(Model,
-            response =>
+            _ =>
             {
-                ApiResponse = response;
+                success = true;
                 return Task.CompletedTask;
             });
-        MudDialog.Close(DialogResult.Ok(true));
+
+        if (success)
+            MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -25,8 +25,9 @@ namespace Sakila.Web.Pages.Countries
 
         private async Task ShowCreateDialog()
         {
-            var dialog = DialogService.ShowAsync<CountryCreateDialog>("Add Country");
-            if (!dialog.IsCompletedSuccessfully)
+            var dialog = await DialogService.ShowAsync<CountryCreateDialog>("Add Country");
+            var result = (await dialog.Result)!;
+            if (!result.Canceled)
             {
                 await RefreshCountries();
             }
@@ -35,8 +36,9 @@ namespace Sakila.Web.Pages.Countries
         private async Task ShowUpdateDialog(CountryGetByIdResponse country)
         {
             var parameters = new DialogParameters { [nameof(CountryUpdateDialog.Country)] = country };
-            var dialog = DialogService.ShowAsync<CountryUpdateDialog>("Edit Country", parameters);
-            if (!dialog.IsCompletedSuccessfully)
+            var dialog = await DialogService.ShowAsync<CountryUpdateDialog>("Edit Country", parameters);
+            var result = (await dialog.Result)!;
+            if (!result.Canceled)
             {
                 await RefreshCountries();
             }
@@ -45,8 +47,9 @@ namespace Sakila.Web.Pages.Countries
         private async Task ShowDeleteDialog(CountryGetByIdResponse country)
         {
             var parameters = new DialogParameters { [nameof(ConfirmDelete.Country)] = country };
-            var dialog = DialogService.ShowAsync<ConfirmDelete>("Delete Country", parameters);
-            if (!dialog.IsCompletedSuccessfully)
+            var dialog = await DialogService.ShowAsync<ConfirmDelete>("Delete Country", parameters);
+            var result = (await dialog.Result)!;
+            if (!result.Canceled)
             {
                 await RefreshCountries();
             }


### PR DESCRIPTION
## Summary
- adjust country dialog markup to match languages
- close country dialogs only when operations succeed
- await dialogs on the countries list page

## Testing
- `dotnet build CRUD-DSC.sln -clp:Summary` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a085dc098832ebd141937ad1cf53f