### PR TITLE
Fix missing EditContext

### DIFF
--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor.cs
@@ -11,6 +11,11 @@ public partial class ConfirmDelete
     [Parameter] public LanguageGetByIdResponse Language { get; set; } = new();
     [Inject] public ILanguageService LanguageService { get; set; } = null!;
 
+    protected override void OnInitialized()
+    {
+        LanguageService.Initialize(Language);
+    }
+
     private async Task ConfirmAsync()
     {
         var success = false;


### PR DESCRIPTION
## Summary
- initialize EditContext for the language delete confirmation dialog

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a0e17ec9c832e865de8976e0805a7