### PR TITLE
Add validation summary for delete

### DIFF
--- a/Sakila.Web/Extensions/EditContextExtensions.cs
+++ b/Sakila.Web/Extensions/EditContextExtensions.cs
@@ -14,7 +14,12 @@ public static class EditContextExtensions
 
         if (response.IsSuccess) return;
 
-        foreach (var (field, messages) in response.Errors) messageStore.Add(editContext.Field(field), messages);
+
+        foreach (var (field, messages) in response.Errors)
+            messageStore.Add(editContext.Field(field), messages);
+
+        foreach (var message in response.GeneralErrors)
+            messageStore.Add(editContext.Field(string.Empty), new[] { message });
 
         editContext.NotifyValidationStateChanged();
     }
@@ -26,7 +31,11 @@ public static class EditContextExtensions
 
         if (response.IsSuccess) return;
 
-        foreach (var (field, messages) in response.Errors) messageStore.Add(editContext.Field(field), messages);
+        foreach (var (field, messages) in response.Errors)
+            messageStore.Add(editContext.Field(field), messages);
+
+        foreach (var message in response.GeneralErrors)
+            messageStore.Add(editContext.Field(string.Empty), new[] { message });
 
         editContext.NotifyValidationStateChanged();
     }

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -4,6 +4,7 @@
             <MudText Typo="Typo.h6">Confirm Deletion</MudText>
             <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
             <DataAnnotationsValidator/>
+            <ValidationSummary />
         </DialogContent>
         <DialogActions>
             <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>


### PR DESCRIPTION
## Summary
- show general API errors in EditContext
- display ValidationSummary in language deletion dialog

## Testing
- `dotnet build CRUD-DSC.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a10097714832e937d4656b0e7a8b3