### PR TITLE
Fix language form resubmission issues

### DIFF
--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -1,14 +1,10 @@
-<EditForm EditContext="LanguageService.EditContext" OnValidSubmit="ConfirmAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudText Typo="Typo.h6">Confirm Deletion</MudText>
-            <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
-            <DataAnnotationsValidator/>
-            <ValidationSummary />
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
-            <MudButton Color="Color.Error" ButtonType="ButtonType.Submit">Yes</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h6">Confirm Deletion</MudText>
+        <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
+        <MudButton Color="Color.Error" OnClick="ConfirmAsync">Yes</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Sakila.Web/Services/BaseCrudService.cs
+++ b/Sakila.Web/Services/BaseCrudService.cs
@@ -28,6 +28,11 @@ public abstract class BaseCrudService<TCreate, TUpdate, TGetAll, TGetById>(
     {
         EditContext = new EditContext(model);
         MessageStore = new ValidationMessageStore(EditContext);
+        EditContext.OnFieldChanged += (sender, args) =>
+        {
+            MessageStore.Clear(args.FieldIdentifier);
+            EditContext.NotifyValidationStateChanged();
+        };
     }
 
     public async Task GetAllAsync(


### PR DESCRIPTION
## Summary
- clear validation errors when fields change
- simplify language delete dialog to allow retries

## Testing
- `dotnet build CRUD-DSC.sln -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a14da9958832ebc4883f1625d5134