### PR TITLE
Simplify forms with reusable dialog component

### DIFF
--- a/Sakila.Web/Components/DialogEditForm.razor
+++ b/Sakila.Web/Components/DialogEditForm.razor
@@ -1,0 +1,22 @@
+@using Microsoft.AspNetCore.Components.Forms
+@using MudBlazor
+
+<EditForm EditContext="@EditContext" OnValidSubmit="@OnValidSubmit">
+    <MudDialog>
+        <DialogContent>
+            @ChildContent
+            <DataAnnotationsValidator />
+        </DialogContent>
+        <DialogActions>
+            @DialogActions
+        </DialogActions>
+        <GeneralValidationSummary />
+    </MudDialog>
+</EditForm>
+
+@code {
+    [Parameter] public EditContext EditContext { get; set; } = default!;
+    [Parameter] public EventCallback OnValidSubmit { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public RenderFragment? DialogActions { get; set; }
+}

--- a/Sakila.Web/Components/GeneralValidationSummary.razor
+++ b/Sakila.Web/Components/GeneralValidationSummary.razor
@@ -1,0 +1,49 @@
+@using Microsoft.AspNetCore.Components.Forms
+@implements IDisposable
+
+@if (_messages.Any())
+{
+    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">
+        <ul class="mud-list">
+            @foreach (var message in _messages)
+            {
+                <li>@message</li>
+            }
+        </ul>
+    </MudAlert>
+}
+
+@code {
+    [CascadingParameter] private EditContext CurrentEditContext { get; set; } = default!;
+    private IEnumerable<string> _messages = Enumerable.Empty<string>();
+
+    protected override void OnInitialized()
+    {
+        if (CurrentEditContext == null)
+        {
+            throw new InvalidOperationException("GeneralValidationSummary must be used inside an EditForm.");
+        }
+        CurrentEditContext.OnValidationStateChanged += OnValidationStateChanged;
+        UpdateMessages();
+    }
+
+    private void OnValidationStateChanged(object? sender, ValidationStateChangedEventArgs e)
+    {
+        UpdateMessages();
+        StateHasChanged();
+    }
+
+    private void UpdateMessages()
+    {
+        var identifier = new FieldIdentifier(CurrentEditContext.Model, string.Empty);
+        _messages = CurrentEditContext.GetValidationMessages(identifier);
+    }
+
+    public void Dispose()
+    {
+        if (CurrentEditContext != null)
+        {
+            CurrentEditContext.OnValidationStateChanged -= OnValidationStateChanged;
+        }
+    }
+}

--- a/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Countries/Components/ConfirmDelete.razor
@@ -1,14 +1,8 @@
-<EditForm EditContext="CountryService.EditContext" OnValidSubmit="ConfirmAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudText Typo="Typo.h6">Confirm Deletion</MudText>
-            <MudText>Are you sure you want to delete <strong>@Country.Name</strong>?</MudText>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
-            <MudButton Color="Color.Error" ButtonType="ButtonType.Submit">Yes</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="CountryService.EditContext" OnValidSubmit="ConfirmAsync">
+    <MudText Typo="Typo.h6">Confirm Deletion</MudText>
+    <MudText>Are you sure you want to delete <strong>@Country.Name</strong>?</MudText>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
+        <MudButton Color="Color.Error" ButtonType="ButtonType.Submit">Yes</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryCreateDialog.razor
@@ -1,13 +1,7 @@
-<EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudTextField @bind-Value="Country.Name" Label="Country Name" For="@(() => Country.Name)" Required="true"/>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
-            <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudTextField @bind-Value="Country.Name" Label="Country Name" For="@(() => Country.Name)" Required="true"/>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
+++ b/Sakila.Web/Pages/Countries/Components/CountryUpdateDialog.razor
@@ -1,14 +1,8 @@
-<EditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudText Typo="Typo.h6">Edit Country</MudText>
-            <MudTextField @bind-Value="Model.Name" Label="Country Name" For="@(() => Model.Name)" Required="true"/>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
-            <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="CountryService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudText Typo="Typo.h6">Edit Country</MudText>
+    <MudTextField @bind-Value="Model.Name" Label="Country Name" For="@(() => Model.Name)" Required="true"/>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
+++ b/Sakila.Web/Pages/Languages/Components/ConfirmDelete.razor
@@ -1,14 +1,8 @@
-<EditForm EditContext="LanguageService.EditContext" OnValidSubmit="ConfirmAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudText Typo="Typo.h6">Confirm Deletion</MudText>
-            <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
-            <MudButton Color="Color.Error" ButtonType="ButtonType.Submit">Yes</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="LanguageService.EditContext" OnValidSubmit="ConfirmAsync">
+    <MudText Typo="Typo.h6">Confirm Deletion</MudText>
+    <MudText>Are you sure you want to delete <strong>@Language.Name</strong>?</MudText>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">No</MudButton>
+        <MudButton Color="Color.Error" ButtonType="ButtonType.Submit">Yes</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageCreateDialog.razor
@@ -1,13 +1,7 @@
-<EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudTextField @bind-Value="Language.Name" Label="Language Name" For="@(() => Language.Name)" Required="true"/>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
-            <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudTextField @bind-Value="Language.Name" Label="Language Name" For="@(() => Language.Name)" Required="true"/>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Add</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
+++ b/Sakila.Web/Pages/Languages/Components/LanguageUpdateDialog.razor
@@ -1,14 +1,8 @@
-<EditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
-    <MudDialog>
-        <DialogContent>
-            <MudText Typo="Typo.h6">Edit Language</MudText>
-            <MudTextField @bind-Value="Model.Name" Label="Language Name" For="@(() => Model.Name)" Required="true"/>
-            <DataAnnotationsValidator/>
-            <ValidationSummary/>
-        </DialogContent>
-        <DialogActions>
-            <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
-            <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
-        </DialogActions>
-    </MudDialog>
-</EditForm>
+<DialogEditForm EditContext="LanguageService.EditContext" OnValidSubmit="SubmitAsync">
+    <MudText Typo="Typo.h6">Edit Language</MudText>
+    <MudTextField @bind-Value="Model.Name" Label="Language Name" For="@(() => Model.Name)" Required="true"/>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" ButtonType="ButtonType.Submit">Edit</MudButton>
+    </DialogActions>
+</DialogEditForm>

--- a/Sakila.Web/_Imports.razor
+++ b/Sakila.Web/_Imports.razor
@@ -8,4 +8,5 @@
 @using Microsoft.JSInterop
 @using Sakila.Web
 @using Sakila.Web.Layout
+@using Sakila.Web.Components
 @using MudBlazor


### PR DESCRIPTION
## Summary
- add new DialogEditForm and GeneralValidationSummary components
- update pages to use the new form component
- import `Sakila.Web.Components` so Razor files find DialogEditForm

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1878d5d0832e9ee45f4f75c2f0b7