### PR TITLE
Refactor dialog handling

### DIFF
--- a/Sakila.Web/Extensions/DialogServiceExtensions.cs
+++ b/Sakila.Web/Extensions/DialogServiceExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Sakila.Web.Extensions;
+
+public static class DialogServiceExtensions
+{
+    public static async Task<IDialogReference> ShowDialogAsync<TDialog>(
+        this IDialogService dialogService,
+        string title,
+        DialogParameters? parameters = null,
+        Func<Task>? onSuccess = null,
+        Func<Task>? onCancel = null)
+        where TDialog : IComponent
+    {
+        var dialog = await dialogService.ShowAsync<TDialog>(title, parameters);
+        var result = await dialog.Result;
+
+        if (!result.Canceled)
+        {
+            if (onSuccess != null)
+                await onSuccess();
+        }
+        else if (onCancel != null)
+        {
+            await onCancel();
+        }
+
+        return dialog;
+    }
+}

--- a/Sakila.Web/Pages/Countries/List.razor.cs
+++ b/Sakila.Web/Pages/Countries/List.razor.cs
@@ -3,6 +3,7 @@ using MudBlazor;
 using Sakila.Contracts.Countries.Queries.Responses;
 using Sakila.Web.Abstractions;
 using Sakila.Web.Pages.Countries.Components;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Countries;
 
@@ -23,26 +24,28 @@ partial class List
         await CountryService.GetAllAsync(r => Task.FromResult(_getAllResponse = r));
     }
 
-    private async Task ShowCreateDialog()
+    private Task ShowCreateDialog()
     {
-        var dialog = await DialogService.ShowAsync<CountryCreateDialog>("Add Country");
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshCountries();
+        return DialogService.ShowDialogAsync<CountryCreateDialog>(
+            "Add Country",
+            onSuccess: RefreshCountries);
     }
 
-    private async Task ShowUpdateDialog(CountryGetByIdResponse country)
+    private Task ShowUpdateDialog(CountryGetByIdResponse country)
     {
         var parameters = new DialogParameters { [nameof(CountryUpdateDialog.Country)] = country };
-        var dialog = await DialogService.ShowAsync<CountryUpdateDialog>("Edit Country", parameters);
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshCountries();
+        return DialogService.ShowDialogAsync<CountryUpdateDialog>(
+            "Edit Country",
+            parameters,
+            RefreshCountries);
     }
 
-    private async Task ShowDeleteDialog(CountryGetByIdResponse country)
+    private Task ShowDeleteDialog(CountryGetByIdResponse country)
     {
         var parameters = new DialogParameters { [nameof(ConfirmDelete.Country)] = country };
-        var dialog = await DialogService.ShowAsync<ConfirmDelete>("Delete Country", parameters);
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshCountries();
+        return DialogService.ShowDialogAsync<ConfirmDelete>(
+            "Delete Country",
+            parameters,
+            RefreshCountries);
     }
 }

--- a/Sakila.Web/Pages/Languages/List.razor.cs
+++ b/Sakila.Web/Pages/Languages/List.razor.cs
@@ -3,6 +3,7 @@ using MudBlazor;
 using Sakila.Contracts.Languages.Queries.Responses;
 using Sakila.Web.Abstractions;
 using Sakila.Web.Pages.Languages.Components;
+using Sakila.Web.Extensions;
 
 namespace Sakila.Web.Pages.Languages;
 
@@ -23,26 +24,28 @@ partial class List
         await LanguageService.GetAllAsync(r => Task.FromResult(_getAllResponse = r));
     }
 
-    private async Task ShowCreateDialog()
+    private Task ShowCreateDialog()
     {
-        var dialog = await DialogService.ShowAsync<LanguageCreateDialog>("Add Language");
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshLanguages();
+        return DialogService.ShowDialogAsync<LanguageCreateDialog>(
+            "Add Language",
+            onSuccess: RefreshLanguages);
     }
 
-    private async Task ShowUpdateDialog(LanguageGetByIdResponse language)
+    private Task ShowUpdateDialog(LanguageGetByIdResponse language)
     {
         var parameters = new DialogParameters { [nameof(LanguageUpdateDialog.Language)] = language };
-        var dialog = await DialogService.ShowAsync<LanguageUpdateDialog>("Edit Language", parameters);
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshLanguages();
+        return DialogService.ShowDialogAsync<LanguageUpdateDialog>(
+            "Edit Language",
+            parameters,
+            RefreshLanguages);
     }
 
-    private async Task ShowDeleteDialog(LanguageGetByIdResponse language)
+    private Task ShowDeleteDialog(LanguageGetByIdResponse language)
     {
         var parameters = new DialogParameters { [nameof(ConfirmDelete.Language)] = language };
-        var dialog = await DialogService.ShowAsync<ConfirmDelete>("Delete Language", parameters);
-        var result = (await dialog.Result)!;
-        if (!result.Canceled) await RefreshLanguages();
+        return DialogService.ShowDialogAsync<ConfirmDelete>(
+            "Delete Language",
+            parameters,
+            RefreshLanguages);
     }
 }


### PR DESCRIPTION
## Summary
- add `DialogServiceExtensions.ShowDialogAsync` helper
- refactor country and language list pages to use the helper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1ca7beb0832e95f97a6439fdca33