### PR TITLE
Fix duplicates in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,5 +364,3 @@ FodyWeavers.xsd
 /Sakila.API/appsettings.json
 /Sakila.Web/wwwroot/appsettings.json
 /Sakila.Web/wwwroot/lib/
-/Sakila.Web/wwwroot/appsettings.json
-/Sakila.API/appsettings.json


### PR DESCRIPTION
## Summary
- remove duplicated `Sakila` settings paths from `.gitignore`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae47d5d74832e8c2ec49d95affe07