### PR TITLE
Introduce ISakilaContext interface

### DIFF
--- a/Sakila.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Sakila.API/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using Sakila.Contracts.Countries.Commands;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Contracts.Languages.Queries;
+using Sakila.Application.Common.Interfaces;
 using Sakila.Infrastructure.Data;
 
 namespace Sakila.API.Extensions;
@@ -47,6 +48,7 @@ public static class ServiceCollectionExtensions
                 options.EnableSensitiveDataLogging()
                     .LogTo(Console.WriteLine, LogLevel.Information);
         });
+        services.AddScoped<ISakilaContext>(sp => sp.GetRequiredService<SakilaContext>());
 
         services
             .AddMediatR(serviceConfiguration =>

--- a/Sakila.Application/Common/Handlers/CreateHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/CreateHandlerBase.cs
@@ -1,12 +1,12 @@
 using AutoMapper;
 using FluentValidation;
 using MediatR;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Common.Handlers;
 
 public abstract class CreateHandlerBase<TRequest, TEntity, TResponse>(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidator<TRequest> validator) : IRequestHandler<TRequest, TResponse>
     where TRequest : IRequest<TResponse> where TEntity : class

--- a/Sakila.Application/Common/Handlers/DeleteHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/DeleteHandlerBase.cs
@@ -1,11 +1,11 @@
 using MediatR;
 using Sakila.Application.Common.Validation;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Common.Handlers;
 
 public abstract class DeleteHandlerBase<TRequest, TEntity, TData>(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IValidatorWithData<TRequest, TData> validator) : IRequestHandler<TRequest, bool>
     where TRequest : IRequest<bool> where TEntity : class
 {

--- a/Sakila.Application/Common/Handlers/UpdateHandlerBase.cs
+++ b/Sakila.Application/Common/Handlers/UpdateHandlerBase.cs
@@ -1,12 +1,12 @@
 using AutoMapper;
 using MediatR;
 using Sakila.Application.Common.Validation;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Common.Handlers;
 
 public abstract class UpdateHandlerBase<TRequest, TEntity, TData>(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<TRequest, TData> validator) : IRequestHandler<TRequest, Unit>
     where TRequest : IRequest<Unit>

--- a/Sakila.Application/Common/Interfaces/ISakilaContext.cs
+++ b/Sakila.Application/Common/Interfaces/ISakilaContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using Sakila.Domain.Models;
+
+namespace Sakila.Application.Common.Interfaces;
+
+public interface ISakilaContext
+{
+    DbSet<Country> Countries { get; }
+    DbSet<Language> Languages { get; }
+    DbSet<TEntity> Set<TEntity>() where TEntity : class;
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/CreateHandler.cs
@@ -3,12 +3,12 @@ using FluentValidation;
 using Sakila.Application.Common.Handlers;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class CreateHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidator<CountryCreateRequest> validator) :
     CreateHandlerBase<CountryCreateRequest, Country, int>(dbContext, mapper, validator)

--- a/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/DeleteHandler.cs
@@ -3,12 +3,12 @@ using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class DeleteHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IValidatorWithData<CountryDeleteRequest, CountryDeleteValidatorData> validator)
     : DeleteHandlerBase<CountryDeleteRequest, Country, CountryDeleteValidatorData>(dbContext, validator)
 {

--- a/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Countries/Commands/Handlers/UpdateHandler.cs
@@ -4,12 +4,12 @@ using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Handlers;
 
 public class UpdateHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData> validator)
     : UpdateHandlerBase<CountryUpdateRequest, Country, CountryUpdateValidatorData>(dbContext, mapper, validator)

--- a/Sakila.Application/Countries/Commands/Validators/CountryCreateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryCreateValidator.cs
@@ -1,12 +1,12 @@
 using FluentValidation;
 using Sakila.Contracts.Countries.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryCreateValidator : AbstractValidator<CountryCreateRequest>
 {
-    public CountryCreateValidator(SakilaContext dbContext)
+    public CountryCreateValidator(ISakilaContext dbContext)
     {
         Include(new Contracts.Countries.Commands.Validators.CountryCreateValidator());
 

--- a/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryDeleteValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryDeleteValidator : ValidatorWithData<CountryDeleteRequest, CountryDeleteValidatorData>
 {
-    public CountryDeleteValidator(SakilaContext dbContext)
+    public CountryDeleteValidator(ISakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>

--- a/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
+++ b/Sakila.Application/Countries/Commands/Validators/CountryUpdateValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Commands.Validators.Data;
 using Sakila.Contracts.Countries.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Commands.Validators;
 
 public class CountryUpdateValidator : ValidatorWithData<CountryUpdateRequest, CountryUpdateValidatorData>
 {
-    public CountryUpdateValidator(SakilaContext dbContext)
+    public CountryUpdateValidator(ISakilaContext dbContext)
     {
         Include(new Contracts.Countries.Commands.Validators.CountryUpdateValidator());
 

--- a/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Countries/Queries/Handlers/GetAllHandler.cs
@@ -3,11 +3,11 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Countries.Queries;
 using Sakila.Contracts.Countries.Queries.Responses;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Queries.Handlers;
 
-public class GetAllHandler(SakilaContext dbContext, IMapper mapper)
+public class GetAllHandler(ISakilaContext dbContext, IMapper mapper)
     : IRequestHandler<CountryGetAllRequest, CountryGetAllResponse>
 {
     public async Task<CountryGetAllResponse> Handle(CountryGetAllRequest request,

--- a/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
+++ b/Sakila.Application/Countries/Queries/Validators/CountryGetByIdValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Countries.Queries.Validators.Data;
 using Sakila.Contracts.Countries.Queries;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Countries.Queries.Validators;
 
 public class CountryGetByIdValidator : ValidatorWithData<CountryGetByIdRequest, CountryGetByIdValidatorData>
 {
-    public CountryGetByIdValidator(SakilaContext dbContext)
+    public CountryGetByIdValidator(ISakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>

--- a/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/CreateHandler.cs
@@ -3,12 +3,12 @@ using FluentValidation;
 using Sakila.Application.Common.Handlers;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class CreateHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidator<LanguageCreateRequest> validator)
     : CreateHandlerBase<LanguageCreateRequest, Language, int>(dbContext, mapper, validator)

--- a/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/DeleteHandler.cs
@@ -3,12 +3,12 @@ using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class DeleteHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData> validator)
     : DeleteHandlerBase<LanguageDeleteRequest, Language, LanguageDeleteValidatorData>(dbContext, validator)
 {

--- a/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
+++ b/Sakila.Application/Languages/Commands/Handlers/UpdateHandler.cs
@@ -4,12 +4,12 @@ using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
 using Sakila.Domain.Models;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Handlers;
 
 public class UpdateHandler(
-    SakilaContext dbContext,
+    ISakilaContext dbContext,
     IMapper mapper,
     IValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData> validator)
     : UpdateHandlerBase<LanguageUpdateRequest, Language, LanguageUpdateValidatorData>(dbContext, mapper, validator)

--- a/Sakila.Application/Languages/Commands/Validators/LanguageCreateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageCreateValidator.cs
@@ -1,12 +1,12 @@
 using FluentValidation;
 using Sakila.Contracts.Languages.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageCreateValidator : AbstractValidator<LanguageCreateRequest>
 {
-    public LanguageCreateValidator(SakilaContext dbContext)
+    public LanguageCreateValidator(ISakilaContext dbContext)
     {
         Include(new Contracts.Languages.Commands.Validators.LanguageCreateValidator());
 

--- a/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageDeleteValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageDeleteValidator : ValidatorWithData<LanguageDeleteRequest, LanguageDeleteValidatorData>
 {
-    public LanguageDeleteValidator(SakilaContext dbContext)
+    public LanguageDeleteValidator(ISakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>

--- a/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
+++ b/Sakila.Application/Languages/Commands/Validators/LanguageUpdateValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Commands.Validators.Data;
 using Sakila.Contracts.Languages.Commands;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Commands.Validators;
 
 public class LanguageUpdateValidator : ValidatorWithData<LanguageUpdateRequest, LanguageUpdateValidatorData>
 {
-    public LanguageUpdateValidator(SakilaContext dbContext)
+    public LanguageUpdateValidator(ISakilaContext dbContext)
     {
         Include(new Contracts.Languages.Commands.Validators.LanguageUpdateValidator());
 

--- a/Sakila.Application/Languages/Queries/Handlers/GetAllHandler.cs
+++ b/Sakila.Application/Languages/Queries/Handlers/GetAllHandler.cs
@@ -3,11 +3,11 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Sakila.Contracts.Languages.Queries;
 using Sakila.Contracts.Languages.Queries.Responses;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Queries.Handlers;
 
-public class GetAllHandler(SakilaContext dbContext, IMapper mapper)
+public class GetAllHandler(ISakilaContext dbContext, IMapper mapper)
     : IRequestHandler<LanguageGetAllRequest, LanguageGetAllResponse>
 {
     public async Task<LanguageGetAllResponse> Handle(LanguageGetAllRequest request,

--- a/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
+++ b/Sakila.Application/Languages/Queries/Validators/LanguageGetByIdValidator.cs
@@ -3,13 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Sakila.Application.Common.Validation;
 using Sakila.Application.Languages.Queries.Validators.Data;
 using Sakila.Contracts.Languages.Queries;
-using Sakila.Infrastructure.Data;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Application.Languages.Queries.Validators;
 
 public class LanguageGetByIdValidator : ValidatorWithData<LanguageGetByIdRequest, LanguageGetByIdValidatorData>
 {
-    public LanguageGetByIdValidator(SakilaContext dbContext)
+    public LanguageGetByIdValidator(ISakilaContext dbContext)
     {
         RuleFor(x => x.Id)
             .MustAsync(async (_, id, ctx, ct) =>

--- a/Sakila.Application/Sakila.Application.csproj
+++ b/Sakila.Application/Sakila.Application.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Sakila.Contracts\Sakila.Contracts.csproj" />
     <ProjectReference Include="..\Sakila.Domain\Sakila.Domain.csproj" />
-    <ProjectReference Include="..\Sakila.Infrastructure\Sakila.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sakila.Infrastructure/Data/SakilaContext.cs
+++ b/Sakila.Infrastructure/Data/SakilaContext.cs
@@ -1,9 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Sakila.Domain.Models;
+using Sakila.Application.Common.Interfaces;
 
 namespace Sakila.Infrastructure.Data;
 
-public partial class SakilaContext : DbContext
+public partial class SakilaContext : DbContext, ISakilaContext
 {
     public SakilaContext()
     {

--- a/Sakila.Infrastructure/Sakila.Infrastructure.csproj
+++ b/Sakila.Infrastructure/Sakila.Infrastructure.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sakila.Domain\Sakila.Domain.csproj" />
+    <ProjectReference Include="..\Sakila.Application\Sakila.Application.csproj" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- introduce `ISakilaContext` interface for Application layer
- use the interface in handlers and validators
- remove Infrastructure reference from Application
- implement the interface in `SakilaContext`
- register the interface in API service collection
- update Infrastructure project to depend on Application

## Testing
- `dotnet build CRUD-DSC.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaa4915c832e9412415abdfce5cc